### PR TITLE
docs: update documentation for v1.0.26 - v1.1.1 releases

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,17 @@ description: {{Track all notable changes, new features, and bug fixes in MBC CQR
 
 ## {{Stable Releases (1.x)}}
 
+## [1.1.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1) (2026-02-07) {#v111}
+
+### {{Bug Fixes}}
+
+- **cli:** {{Add missing `import_tmp.json` DynamoDB table template}} ([{{See Details}}](/docs/dynamodb#system-table-definitions)) ([PR #323](https://github.com/mbc-net/mbc-cqrs-serverless/pull/323))
+  - {{The `import_tmp` table definition was missing from CLI templates, causing `npm run offline:sls` to fail}}
+  - {{The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration}}
+  - {{See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions}}
+
+---
+
 ## [1.1.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0) (2026-02-03) {#v110}
 
 ### {{Breaking Changes}}

--- a/docs/dynamodb.md
+++ b/docs/dynamodb.md
@@ -21,6 +21,7 @@ graph TB
     subgraph "{{System Tables}}"
         D["{{tasks}}"]
         E["{{sequences}}"]
+        F["{{import_tmp}}"]
     end
 
     A -->|"{{DynamoDB Streams}}"| B
@@ -43,6 +44,7 @@ graph TB
 |--------|---------|
 | `tasks` | {{Stores information about long-running asynchronous tasks}} |
 | `sequences` | {{Holds sequence data for ID generation}} |
+| `import_tmp` | {{Stores temporary data for import operations via Step Functions}} |
 
 ## {{Table Definition}}
 
@@ -67,6 +69,20 @@ npm run migrate:ddb
 # Migrate both DynamoDB and RDS
 npm run migrate
 ```
+
+### {{System Table Definitions}} {#system-table-definitions}
+
+{{System tables (`tasks`, `sequences`, `import_tmp`) have their own JSON definition files in the `prisma/dynamodbs/` folder. These are automatically created during migration:}}
+
+| {{File}} | {{Table}} | {{Purpose}} |
+|------|---------|---------|
+| `tasks.json` | `tasks` | {{Task management with DynamoDB Streams}} |
+| `sequences.json` | `sequences` | {{Sequence ID generation}} |
+| `import_tmp.json` | `import_tmp` | {{Temporary import data with DynamoDB Streams for [ImportModule](/docs/import)}} |
+
+:::info {{Version Note}}
+{{The `import_tmp.json` template was added in [version 1.1.1](/docs/changelog#v111). If you created your project with an earlier version and use the ImportModule, you need to add this file manually. See [Common Issues](/docs/common-issues#missing-import-tmp-table) for details.}}
+:::
 
 ## {{Key Design Patterns}}
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/changelog.md
@@ -17,6 +17,17 @@ All notable changes to MBC CQRS Serverless are documented here. This project fol
 
 ## Stable Releases (1.x)
 
+## [1.1.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1) (2026-02-07) {#v111}
+
+### Bug Fixes
+
+- **cli:** Add missing `import_tmp.json` DynamoDB table template ([See Details](/docs/dynamodb#system-table-definitions)) ([PR #323](https://github.com/mbc-net/mbc-cqrs-serverless/pull/323))
+  - The `import_tmp` table definition was missing from CLI templates, causing `npm run offline:sls` to fail
+  - The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration
+  - See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions
+
+---
+
 ## [1.1.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0) (2026-02-03) {#v110}
 
 ### Breaking Changes

--- a/i18n/en/docusaurus-plugin-content-docs/current/common-issues.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/common-issues.md
@@ -174,6 +174,49 @@ aws dynamodb list-tables --endpoint-url http://localhost:8000 | grep master
 # Should show: master-command, master-data, master-history
 ```
 
+### Serverless Offline fails with missing import_tmp stream {#missing-import-tmp-table}
+
+**Symptom**: `npm run offline:sls` fails because the `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable is not set.
+
+**Cause**: The `import_tmp.json` table definition file is missing from `prisma/dynamodbs/`. Without it, `npm run migrate` cannot create the `import_tmp` DynamoDB table, so the stream ARN is never written to `.env`.
+
+:::warning Known Issue (Fixed in v1.1.1)
+In versions prior to v1.1.1, the `import_tmp.json` template was not included in CLI scaffolded projects. This was fixed in [version 1.1.1](/docs/changelog#v111).
+:::
+
+**Solution**:
+
+Create `prisma/dynamodbs/import_tmp.json` with the following content:
+
+```json
+{
+  "TableName": "import_tmp",
+  "AttributeDefinitions": [
+    { "AttributeName": "pk", "AttributeType": "S" },
+    { "AttributeName": "sk", "AttributeType": "S" }
+  ],
+  "KeySchema": [
+    { "AttributeName": "pk", "KeyType": "HASH" },
+    { "AttributeName": "sk", "KeyType": "RANGE" }
+  ],
+  "BillingMode": "PAY_PER_REQUEST",
+  "StreamSpecification": {
+    "StreamEnabled": true,
+    "StreamViewType": "NEW_IMAGE"
+  },
+  "TableClass": "STANDARD",
+  "DeletionProtectionEnabled": true
+}
+```
+
+Then re-run the migration:
+
+```bash
+npm run migrate
+```
+
+The migration script will automatically create the table and add the `LOCAL_DDB_IMPORT_TMP_STREAM` entry to your `.env` file.
+
 ### DynamoDB throughput exceeded
 
 **Symptom**: ProvisionedThroughputExceededException error.

--- a/i18n/en/docusaurus-plugin-content-docs/current/dynamodb.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/dynamodb.md
@@ -21,6 +21,7 @@ graph TB
     subgraph "System Tables"
         D["tasks"]
         E["sequences"]
+        F["import_tmp"]
     end
 
     A -->|"DynamoDB Streams"| B
@@ -43,6 +44,7 @@ In the MBC CQRS Serverless, DynamoDB tables are organized into the following typ
 |--------|---------|
 | `tasks` | Stores information about long-running asynchronous tasks |
 | `sequences` | Holds sequence data for ID generation |
+| `import_tmp` | Stores temporary data for import operations via Step Functions |
 
 ## Table Definition
 
@@ -67,6 +69,20 @@ npm run migrate:ddb
 # Migrate both DynamoDB and RDS
 npm run migrate
 ```
+
+### System Table Definitions {#system-table-definitions}
+
+System tables (`tasks`, `sequences`, `import_tmp`) have their own JSON definition files in the `prisma/dynamodbs/` folder. These are automatically created during migration:
+
+| File | Table | Purpose |
+|------|---------|---------|
+| `tasks.json` | `tasks` | Task management with DynamoDB Streams |
+| `sequences.json` | `sequences` | Sequence ID generation |
+| `import_tmp.json` | `import_tmp` | Temporary import data with DynamoDB Streams for [ImportModule](/docs/import) |
+
+:::info Version Note
+The `import_tmp.json` template was added in [version 1.1.1](/docs/changelog#v111). If you created your project with an earlier version and use the ImportModule, you need to add this file manually. See [Common Issues](/docs/common-issues#missing-import-tmp-table) for details.
+:::
 
 ## Key Design Patterns
 

--- a/i18n/en/translation/changelog.json
+++ b/i18n/en/translation/changelog.json
@@ -228,5 +228,9 @@
   "Add comprehensive dependency integration tests (3400+ tests)": "Add comprehensive dependency integration tests (3400+ tests)",
   "AWS SDK integration tests (DynamoDB, S3, SNS, SQS, Step Functions, SES)": "AWS SDK integration tests (DynamoDB, S3, SNS, SQS, Step Functions, SES)",
   "NestJS behavior tests (decorators, config, DI, Swagger)": "NestJS behavior tests (decorators, config, DI, Swagger)",
-  "Third-party library tests (class-transformer, class-validator, RxJS)": "Third-party library tests (class-transformer, class-validator, RxJS)"
+  "Third-party library tests (class-transformer, class-validator, RxJS)": "Third-party library tests (class-transformer, class-validator, RxJS)",
+  "Add missing `import_tmp.json` DynamoDB table template": "Add missing `import_tmp.json` DynamoDB table template",
+  "The `import_tmp` table definition was missing from CLI templates, causing `npm run offline:sls` to fail": "The `import_tmp` table definition was missing from CLI templates, causing `npm run offline:sls` to fail",
+  "The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration": "The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration",
+  "See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions": "See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions"
 }

--- a/i18n/en/translation/common-issues.json
+++ b/i18n/en/translation/common-issues.json
@@ -130,5 +130,13 @@
   "If the table is missing, add it to your Prisma schema:": "If the table is missing, add it to your Prisma schema:",
   "Run Prisma migration:": "Run Prisma migration:",
   "Verify the DynamoDB tables also exist:": "Verify the DynamoDB tables also exist:",
-  "Should show: master-command, master-data, master-history": "Should show: master-command, master-data, master-history"
+  "Should show: master-command, master-data, master-history": "Should show: master-command, master-data, master-history",
+  "Serverless Offline fails with missing import_tmp stream": "Serverless Offline fails with missing import_tmp stream",
+  "`npm run offline:sls` fails because the `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable is not set.": "`npm run offline:sls` fails because the `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable is not set.",
+  "The `import_tmp.json` table definition file is missing from `prisma/dynamodbs/`. Without it, `npm run migrate` cannot create the `import_tmp` DynamoDB table, so the stream ARN is never written to `.env`.": "The `import_tmp.json` table definition file is missing from `prisma/dynamodbs/`. Without it, `npm run migrate` cannot create the `import_tmp` DynamoDB table, so the stream ARN is never written to `.env`.",
+  "Known Issue (Fixed in v1.1.1)": "Known Issue (Fixed in v1.1.1)",
+  "In versions prior to v1.1.1, the `import_tmp.json` template was not included in CLI scaffolded projects. This was fixed in [version 1.1.1](/docs/changelog#v111).": "In versions prior to v1.1.1, the `import_tmp.json` template was not included in CLI scaffolded projects. This was fixed in [version 1.1.1](/docs/changelog#v111).",
+  "Create `prisma/dynamodbs/import_tmp.json` with the following content:": "Create `prisma/dynamodbs/import_tmp.json` with the following content:",
+  "Then re-run the migration:": "Then re-run the migration:",
+  "The migration script will automatically create the table and add the `LOCAL_DDB_IMPORT_TMP_STREAM` entry to your `.env` file.": "The migration script will automatically create the table and add the `LOCAL_DDB_IMPORT_TMP_STREAM` entry to your `.env` file."
 }

--- a/i18n/en/translation/dynamodb.json
+++ b/i18n/en/translation/dynamodb.json
@@ -98,5 +98,15 @@
   "[Key Patterns](./key-patterns.md): Detailed key design strategies": "[Key Patterns](./key-patterns.md): Detailed key design strategies",
   "[Entity Patterns](./entity-patterns.md): Entity modeling guidelines": "[Entity Patterns](./entity-patterns.md): Entity modeling guidelines",
   "[Sequence](./sequence.md): Sequence ID generation": "[Sequence](./sequence.md): Sequence ID generation",
-  "[CommandService](./command-service.md): Command handling and data sync": "[CommandService](./command-service.md): Command handling and data sync"
+  "[CommandService](./command-service.md): Command handling and data sync": "[CommandService](./command-service.md): Command handling and data sync",
+  "import_tmp": "import_tmp",
+  "Stores temporary data for import operations via Step Functions": "Stores temporary data for import operations via Step Functions",
+  "System Table Definitions": "System Table Definitions",
+  "System tables (`tasks`, `sequences`, `import_tmp`) have their own JSON definition files in the `prisma/dynamodbs/` folder. These are automatically created during migration:": "System tables (`tasks`, `sequences`, `import_tmp`) have their own JSON definition files in the `prisma/dynamodbs/` folder. These are automatically created during migration:",
+  "File": "File",
+  "Task management with DynamoDB Streams": "Task management with DynamoDB Streams",
+  "Sequence ID generation": "Sequence ID generation",
+  "Temporary import data with DynamoDB Streams for [ImportModule](/docs/import)": "Temporary import data with DynamoDB Streams for [ImportModule](/docs/import)",
+  "Version Note": "Version Note",
+  "The `import_tmp.json` template was added in [version 1.1.1](/docs/changelog#v111). If you created your project with an earlier version and use the ImportModule, you need to add this file manually. See [Common Issues](/docs/common-issues#missing-import-tmp-table) for details.": "The `import_tmp.json` template was added in [version 1.1.1](/docs/changelog#v111). If you created your project with an earlier version and use the ImportModule, you need to add this file manually. See [Common Issues](/docs/common-issues#missing-import-tmp-table) for details."
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/changelog.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/changelog.md
@@ -17,6 +17,17 @@ MBC CQRS Serverlessのすべての注目すべき変更がここに記録され�
 
 ## 安定版リリース (1.x)
 
+## [1.1.1](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1) (2026-02-07) {#v111}
+
+### バグ修正
+
+- **cli:** 不足していた`import_tmp.json` DynamoDBテーブルテンプレートを追加 ([詳細を見る](/docs/dynamodb#system-table-definitions)) ([PR #323](https://github.com/mbc-net/mbc-cqrs-serverless/pull/323))
+  - CLIテンプレートに`import_tmp`テーブル定義が含まれておらず、`npm run offline:sls`が失敗していました
+  - `serverless.yml`が参照する`LOCAL_DDB_IMPORT_TMP_STREAM`環境変数は、マイグレーション時にテーブルが作成される必要があります
+  - 以前のバージョンを使用している場合の回避策は[よくある問題](/docs/common-issues#missing-import-tmp-table)を参照
+
+---
+
 ## [1.1.0](https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0) (2026-02-03) {#v110}
 
 ### 破壊的変更

--- a/i18n/ja/docusaurus-plugin-content-docs/current/dynamodb.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/dynamodb.md
@@ -21,6 +21,7 @@ graph TB
     subgraph "システムテーブル"
         D["tasks"]
         E["sequences"]
+        F["import_tmp"]
     end
 
     A -->|"DynamoDB Streams"| B
@@ -43,6 +44,7 @@ MBC CQRS Serverlessでは、DynamoDBテーブルは以下のタイプに整理�
 |--------|---------|
 | `tasks` | 長時間実行される非同期タスクの情報を保存 |
 | `sequences` | ID生成用のシーケンスデータを保持 |
+| `import_tmp` | Step Functionsを介したインポート操作用の一時データを保存 |
 
 ## テーブル定義
 
@@ -67,6 +69,20 @@ npm run migrate:ddb
 # Migrate both DynamoDB and RDS
 npm run migrate
 ```
+
+### システムテーブル定義 {#system-table-definitions}
+
+システムテーブル（`tasks`、`sequences`、`import_tmp`）は`prisma/dynamodbs/`フォルダに独自のJSON定義ファイルがあります。マイグレーション時に自動的に作成されます：
+
+| ファイル | テーブル | 用途 |
+|------|---------|---------|
+| `tasks.json` | `tasks` | DynamoDB Streamsによるタスク管理 |
+| `sequences.json` | `sequences` | シーケンスID生成 |
+| `import_tmp.json` | `import_tmp` | [ImportModule](/docs/import)用のDynamoDB Streams付き一時インポートデータ |
+
+:::info バージョン情報
+`import_tmp.json`テンプレートは[バージョン1.1.1](/docs/changelog#v111)で追加されました。それ以前のバージョンでプロジェクトを作成し、ImportModuleを使用している場合は、このファイルを手動で追加する必要があります。詳細は[よくある問題](/docs/common-issues#missing-import-tmp-table)を参照してください。
+:::
 
 ## キー設計パターン
 

--- a/i18n/ja/translation/changelog.json
+++ b/i18n/ja/translation/changelog.json
@@ -228,5 +228,9 @@
   "Add comprehensive dependency integration tests (3400+ tests)": "包括的な依存関係統合テストを追加（3400以上のテスト）",
   "AWS SDK integration tests (DynamoDB, S3, SNS, SQS, Step Functions, SES)": "AWS SDK統合テスト（DynamoDB、S3、SNS、SQS、Step Functions、SES）",
   "NestJS behavior tests (decorators, config, DI, Swagger)": "NestJS動作テスト（デコレーター、設定、DI、Swagger）",
-  "Third-party library tests (class-transformer, class-validator, RxJS)": "サードパーティライブラリテスト（class-transformer、class-validator、RxJS）"
+  "Third-party library tests (class-transformer, class-validator, RxJS)": "サードパーティライブラリテスト（class-transformer、class-validator、RxJS）",
+  "Add missing `import_tmp.json` DynamoDB table template": "不足していた`import_tmp.json` DynamoDBテーブルテンプレートを追加",
+  "The `import_tmp` table definition was missing from CLI templates, causing `npm run offline:sls` to fail": "CLIテンプレートに`import_tmp`テーブル定義が含まれておらず、`npm run offline:sls`が失敗していました",
+  "The `serverless.yml` references `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable, which requires the table to be created during migration": "`serverless.yml`が参照する`LOCAL_DDB_IMPORT_TMP_STREAM`環境変数は、マイグレーション時にテーブルが作成される必要があります",
+  "See [Common Issues](/docs/common-issues#missing-import-tmp-table) for workaround if using older versions": "以前のバージョンを使用している場合の回避策は[よくある問題](/docs/common-issues#missing-import-tmp-table)を参照"
 }

--- a/i18n/ja/translation/common-issues.json
+++ b/i18n/ja/translation/common-issues.json
@@ -130,5 +130,13 @@
   "If the table is missing, add it to your Prisma schema:": "テーブルがない場合は、Prismaスキーマに追加：",
   "Run Prisma migration:": "Prismaマイグレーションを実行：",
   "Verify the DynamoDB tables also exist:": "DynamoDBテーブルも存在することを確認：",
-  "Should show: master-command, master-data, master-history": "表示されるはず: master-command, master-data, master-history"
+  "Should show: master-command, master-data, master-history": "表示されるはず: master-command, master-data, master-history",
+  "Serverless Offline fails with missing import_tmp stream": "import_tmpストリームが見つからずServerless Offlineが失敗する",
+  "`npm run offline:sls` fails because the `LOCAL_DDB_IMPORT_TMP_STREAM` environment variable is not set.": "`LOCAL_DDB_IMPORT_TMP_STREAM`環境変数が設定されていないため、`npm run offline:sls`が失敗する。",
+  "The `import_tmp.json` table definition file is missing from `prisma/dynamodbs/`. Without it, `npm run migrate` cannot create the `import_tmp` DynamoDB table, so the stream ARN is never written to `.env`.": "`prisma/dynamodbs/`に`import_tmp.json`テーブル定義ファイルがありません。これがないと、`npm run migrate`が`import_tmp` DynamoDBテーブルを作成できず、ストリームARNが`.env`に書き込まれません。",
+  "Known Issue (Fixed in v1.1.1)": "既知の問題（v1.1.1で修正済み）",
+  "In versions prior to v1.1.1, the `import_tmp.json` template was not included in CLI scaffolded projects. This was fixed in [version 1.1.1](/docs/changelog#v111).": "v1.1.1より前のバージョンでは、CLIでスキャフォールドされたプロジェクトに`import_tmp.json`テンプレートが含まれていませんでした。これは[バージョン1.1.1](/docs/changelog#v111)で修正されました。",
+  "Create `prisma/dynamodbs/import_tmp.json` with the following content:": "以下の内容で`prisma/dynamodbs/import_tmp.json`を作成してください：",
+  "Then re-run the migration:": "その後、マイグレーションを再実行してください：",
+  "The migration script will automatically create the table and add the `LOCAL_DDB_IMPORT_TMP_STREAM` entry to your `.env` file.": "マイグレーションスクリプトが自動的にテーブルを作成し、`LOCAL_DDB_IMPORT_TMP_STREAM`エントリを`.env`ファイルに追加します。"
 }

--- a/i18n/ja/translation/dynamodb.json
+++ b/i18n/ja/translation/dynamodb.json
@@ -98,5 +98,15 @@
   "[Key Patterns](./key-patterns.md): Detailed key design strategies": "[Key Patterns](./key-patterns.md): 詳細なキー設計戦略",
   "[Entity Patterns](./entity-patterns.md): Entity modeling guidelines": "[Entity Patterns](./entity-patterns.md): エンティティモデリングガイドライン",
   "[Sequence](./sequence.md): Sequence ID generation": "[Sequence](./sequence.md): シーケンスID生成",
-  "[CommandService](./command-service.md): Command handling and data sync": "[CommandService](./command-service.md): コマンド処理とデータ同期"
+  "[CommandService](./command-service.md): Command handling and data sync": "[CommandService](./command-service.md): コマンド処理とデータ同期",
+  "import_tmp": "import_tmp",
+  "Stores temporary data for import operations via Step Functions": "Step Functionsを介したインポート操作用の一時データを保存",
+  "System Table Definitions": "システムテーブル定義",
+  "System tables (`tasks`, `sequences`, `import_tmp`) have their own JSON definition files in the `prisma/dynamodbs/` folder. These are automatically created during migration:": "システムテーブル（`tasks`、`sequences`、`import_tmp`）は`prisma/dynamodbs/`フォルダに独自のJSON定義ファイルがあります。マイグレーション時に自動的に作成されます：",
+  "File": "ファイル",
+  "Task management with DynamoDB Streams": "DynamoDB Streamsによるタスク管理",
+  "Sequence ID generation": "シーケンスID生成",
+  "Temporary import data with DynamoDB Streams for [ImportModule](/docs/import)": "[ImportModule](/docs/import)用のDynamoDB Streams付き一時インポートデータ",
+  "Version Note": "バージョン情報",
+  "The `import_tmp.json` template was added in [version 1.1.1](/docs/changelog#v111). If you created your project with an earlier version and use the ImportModule, you need to add this file manually. See [Common Issues](/docs/common-issues#missing-import-tmp-table) for details.": "`import_tmp.json`テンプレートは[バージョン1.1.1](/docs/changelog#v111)で追加されました。それ以前のバージョンでプロジェクトを作成し、ImportModuleを使用している場合は、このファイルを手動で追加する必要があります。詳細は[よくある問題](/docs/common-issues#missing-import-tmp-table)を参照してください。"
 }

--- a/static/api/releases-ja.json
+++ b/static/api/releases-ja.json
@@ -1,24 +1,25 @@
 {
   "latest": {
-    "version": "1.1.0",
-    "date": "2026-02-03",
-    "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0",
-    "features": [
-      "大文字小文字を区別しないマッチングのためのテナントコード正規化を追加",
-      "明示的な正規化のための`normalizeTenantCode()`ユーティリティ関数を追加",
-      "共通テナント検出のための`isCommonTenant()`ユーティリティ関数を追加",
-      "AWS SESメールのカテゴリ分けとフィルタリング用EmailTagsサポートを追加",
-      "RolesGuardに拡張可能なテナント検証を追加",
-      "スキル更新用のnpmレジストリバージョンチェックを追加"
-    ],
+    "version": "1.1.1",
+    "date": "2026-02-07",
+    "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1",
+    "features": [],
     "bugFixes": [
-      "MasterSettingServiceとMasterDataServiceでの`TENANT_COMMON`定数の使用を修正"
+      "不足していた`import_tmp.json` DynamoDBテーブルテンプレートを追加"
     ],
-    "security": [
-      "**core:** テナントコードヘッダーオーバーライドをシステム管理者のみに制限"
-    ]
+    "security": []
   },
   "recent": [
+    {
+      "version": "1.1.1",
+      "date": "2026-02-07",
+      "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1",
+      "features": [],
+      "bugFixes": [
+        "不足していた`import_tmp.json` DynamoDBテーブルテンプレートを追加"
+      ],
+      "security": []
+    },
     {
       "version": "1.1.0",
       "date": "2026-02-03",
@@ -60,20 +61,7 @@
       ],
       "bugFixes": [],
       "security": []
-    },
-    {
-      "version": "1.0.24",
-      "date": "2026-01-17",
-      "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.24",
-      "features": [
-        "ガイド付き開発支援のためのClaude Code Skillsを追加",
-        "簡単なskillsインストールのための`mbc install-skills`コマンドを追加"
-      ],
-      "bugFixes": [
-        "パラメータ名のタイポを修正：`skExpession`を`skExpression`に"
-      ],
-      "security": []
     }
   ],
-  "generated": "2026-02-03T04:36:49.876Z"
+  "generated": "2026-02-07T05:06:44.940Z"
 }

--- a/static/api/releases.json
+++ b/static/api/releases.json
@@ -1,22 +1,25 @@
 {
   "latest": {
-    "version": "1.1.0",
-    "date": "2026-02-03",
-    "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.0",
-    "features": [
-      "Add tenant code normalization for case-insensitive matching",
-      "Add `normalizeTenantCode()` utility function for explicit normalization",
-      "Add `isCommonTenant()` utility function for common tenant detection",
-      "Add EmailTags support for AWS SES email categorization and filtering",
-      "Add extensible tenant verification in RolesGuard",
-      "Add npm registry version check for skill updates"
-    ],
+    "version": "1.1.1",
+    "date": "2026-02-07",
+    "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1",
+    "features": [],
     "bugFixes": [
-      "Fix `TENANT_COMMON` constant usage in MasterSettingService and MasterDataService"
+      "Add missing `import_tmp.json` DynamoDB table template"
     ],
     "security": []
   },
   "recent": [
+    {
+      "version": "1.1.1",
+      "date": "2026-02-07",
+      "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.1.1",
+      "features": [],
+      "bugFixes": [
+        "Add missing `import_tmp.json` DynamoDB table template"
+      ],
+      "security": []
+    },
     {
       "version": "1.1.0",
       "date": "2026-02-03",
@@ -56,20 +59,7 @@
       ],
       "bugFixes": [],
       "security": []
-    },
-    {
-      "version": "1.0.24",
-      "date": "2026-01-17",
-      "url": "https://github.com/mbc-net/mbc-cqrs-serverless/releases/tag/v1.0.24",
-      "features": [
-        "Add Claude Code Skills for guided development assistance",
-        "Add `mbc install-skills` command for easy skills installation"
-      ],
-      "bugFixes": [
-        "Fix typo in parameter name `skExpession` to `skExpression`"
-      ],
-      "security": []
     }
   ],
-  "generated": "2026-02-03T04:36:49.874Z"
+  "generated": "2026-02-07T05:06:44.935Z"
 }


### PR DESCRIPTION
## Summary
- Add documentation for v1.0.26 configurable local service ports
- Add v1.1.0 changelog, migration guide, and related documentation updates (tenant code normalization, breaking changes, EmailTags, RolesGuard)
- Add v1.1.1 changelog entry for missing `import_tmp.json` DynamoDB table template fix
- Add common-issues entry and dynamodb system table definitions section
- Update releases JSON files (en/ja) with v1.1.1 as latest

## Test plan
- [ ] Verify cross-links work in English and Japanese versions
- [ ] Verify `releases-ja.json` and `releases.json` contain v1.1.1 as latest
- [ ] Build and deploy to confirm WordPress service page auto-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)