### PR TITLE
docs(i18n): translate Related Documentation link texts in backend-development.md

### DIFF
--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -536,8 +536,8 @@ async searchWithPagination(
 
 ## {{Related Documentation}}
 
-- [Service Patterns](/docs/service-patterns) - {{Advanced service implementation patterns}}
-- [Data Sync Handler Examples](/docs/data-sync-handler-examples) - {{Comprehensive sync handler examples}}
-- [Key Patterns](/docs/key-patterns) - {{PK/SK design patterns}}
-- [Multi-Tenant Patterns](/docs/multi-tenant-patterns) - {{Multi-tenant implementation}}
-- [Import/Export Patterns](/docs/import-export-patterns) - {{Batch data processing}}
+- [{{Service Patterns}}](/docs/service-patterns) - {{Advanced service implementation patterns}}
+- [{{Data Sync Handler Examples}}](/docs/data-sync-handler-examples) - {{Comprehensive sync handler examples}}
+- [{{Key Patterns}}](/docs/key-patterns) - {{PK/SK design patterns}}
+- [{{Multi-Tenant Patterns}}](/docs/multi-tenant-patterns) - {{Multi-tenant implementation}}
+- [{{Import/Export Patterns}}](/docs/import-export-patterns) - {{Batch data processing}}

--- a/i18n/en/translation/backend-development.json
+++ b/i18n/en/translation/backend-development.json
@@ -52,9 +52,14 @@
   "5. Pagination": "5. Pagination",
   "Always support pagination for list operations:": "Always support pagination for list operations:",
   "Related Documentation": "Related Documentation",
+  "Service Patterns": "Service Patterns",
   "Advanced service implementation patterns": "Advanced service implementation patterns",
+  "Data Sync Handler Examples": "Data Sync Handler Examples",
   "Comprehensive sync handler examples": "Comprehensive sync handler examples",
+  "Key Patterns": "Key Patterns",
   "PK/SK design patterns": "PK/SK design patterns",
+  "Multi-Tenant Patterns": "Multi-Tenant Patterns",
   "Multi-tenant implementation": "Multi-tenant implementation",
+  "Import/Export Patterns": "Import/Export Patterns",
   "Batch data processing": "Batch data processing"
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/backend-development.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/backend-development.md
@@ -536,8 +536,8 @@ async searchWithPagination(
 
 ## 関連ドキュメント
 
-- [Service Patterns](/docs/service-patterns) - 高度なサービス実装パターン
-- [Data Sync Handler Examples](/docs/data-sync-handler-examples) - 包括的な同期ハンドラー例
-- [Key Patterns](/docs/key-patterns) - PK/SK設計パターン
-- [Multi-Tenant Patterns](/docs/multi-tenant-patterns) - マルチテナント実装
-- [Import/Export Patterns](/docs/import-export-patterns) - バッチデータ処理
+- [サービスパターン](/docs/service-patterns) - 高度なサービス実装パターン
+- [Data Sync Handlerの実装例](/docs/data-sync-handler-examples) - 包括的な同期ハンドラー例
+- [キーパターン](/docs/key-patterns) - PK/SK設計パターン
+- [マルチテナントパターン](/docs/multi-tenant-patterns) - マルチテナント実装
+- [インポート/エクスポートパターン](/docs/import-export-patterns) - バッチデータ処理

--- a/i18n/ja/translation/backend-development.json
+++ b/i18n/ja/translation/backend-development.json
@@ -52,9 +52,14 @@
   "5. Pagination": "5. ページネーション",
   "Always support pagination for list operations:": "一覧操作では常にページネーションをサポートします：",
   "Related Documentation": "関連ドキュメント",
+  "Service Patterns": "サービスパターン",
   "Advanced service implementation patterns": "高度なサービス実装パターン",
+  "Data Sync Handler Examples": "Data Sync Handlerの実装例",
   "Comprehensive sync handler examples": "包括的な同期ハンドラー例",
+  "Key Patterns": "キーパターン",
   "PK/SK design patterns": "PK/SK設計パターン",
+  "Multi-Tenant Patterns": "マルチテナントパターン",
   "Multi-tenant implementation": "マルチテナント実装",
+  "Import/Export Patterns": "インポート/エクスポートパターン",
   "Batch data processing": "バッチデータ処理"
 }


### PR DESCRIPTION
## Summary

`backend-development.md` の「関連ドキュメント」セクションのリンクアンカーテキストが英語のままだった問題を修正します。

**修正前（日本語版）**:
- [Data Sync Handler Examples](/docs/data-sync-handler-examples)
- [Multi-Tenant Patterns](/docs/multi-tenant-patterns)

**修正後（日本語版）**:
- [Data Sync Handlerの実装例](/docs/data-sync-handler-examples)
- [マルチテナントパターン](/docs/multi-tenant-patterns)

これにより、リンクテキストが各ドキュメントの日本語H1タイトルと一致するようになります。

## Test plan

- [x] `npm run build` がエラー・警告なしで成功
- [x] 日本語版 backend-development.md のリンクテキストが日本語化

🤖 Generated with [Claude Code](https://claude.com/claude-code)