### PR TITLE
fix(i18n): translate remaining Japanese UI labels in navbar and code.json

### DIFF
--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -344,11 +344,11 @@
     "description": "The title of the page for a blog author"
   },
   "theme.blog.authorsList.pageTitle": {
-    "message": "Authors",
+    "message": "著者一覧",
     "description": "The title of the authors page"
   },
   "theme.blog.authorsList.viewAll": {
-    "message": "View All Authors",
+    "message": "全著者を見る",
     "description": "The label of the link targeting the blog authors page"
   },
   "theme.contentVisibility.unlistedBanner.title": {
@@ -360,11 +360,11 @@
     "description": "The unlisted content banner message"
   },
   "theme.contentVisibility.draftBanner.title": {
-    "message": "Draft page",
+    "message": "下書きページ",
     "description": "The draft content banner title"
   },
   "theme.contentVisibility.draftBanner.message": {
-    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "message": "このページは下書きです。開発環境でのみ表示されます。",
     "description": "The draft content banner message"
   },
   "theme.ErrorPageContent.tryAgain": {

--- a/i18n/ja/docusaurus-theme-classic/navbar.json
+++ b/i18n/ja/docusaurus-theme-classic/navbar.json
@@ -8,7 +8,7 @@
     "description": "The alt text of navbar logo"
   },
   "item.label.Docs": {
-    "message": "Docs",
+    "message": "ドキュメント",
     "description": "Navbar item with label Docs"
   },
   "item.label.GitHub": {


### PR DESCRIPTION
## Summary

日本語版UIのナビゲーションバーとシステムメッセージで英語のままになっていた箇所を修正します。

**修正内容**:
- `navbar.json`: `Docs` → `ドキュメント`（ナビゲーションバーのラベル）
- `code.json` UIラベルの日本語化:
  - `Authors` → `著者一覧`
  - `View All Authors` → `全著者を見る`
  - `Draft page` → `下書きページ`
  - Draft banner message → 日本語翻訳

## Test plan

- [x] `npm run build` がエラー・警告なしで成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)