### PR TITLE
docs: unify 'See Also' to 'Related Documentation' in error-catalog.md

### DIFF
--- a/docs/error-catalog.md
+++ b/docs/error-catalog.md
@@ -874,7 +874,7 @@ class CircuitBreaker {
    npm run offline -- --stage dev
    ```
 
-## {{See Also}}
+## {{Related Documentation}}
 
 - {{[Debugging Guide](/docs/debugging-guide) - Detailed debugging procedures}}
 - {{[Common Issues](/docs/common-issues) - Frequently encountered problems}}

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-catalog.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-catalog.md
@@ -874,7 +874,7 @@ class CircuitBreaker {
    npm run offline -- --stage dev
    ```
 
-## See Also
+## Related Documentation
 
 - [Debugging Guide](/docs/debugging-guide) - Detailed debugging procedures
 - [Common Issues](/docs/common-issues) - Frequently encountered problems

--- a/i18n/en/translation/error-catalog.json
+++ b/i18n/en/translation/error-catalog.json
@@ -190,7 +190,7 @@
   "Use request IDs for tracing": "Use request IDs for tracing",
   "Verify environment variables": "Verify environment variables",
   "Test locally with serverless-offline": "Test locally with serverless-offline",
-  "See Also": "See Also",
+  "Related Documentation": "Related Documentation",
   "[Debugging Guide](/docs/debugging-guide) - Detailed debugging procedures": "[Debugging Guide](/docs/debugging-guide) - Detailed debugging procedures",
   "[Common Issues](/docs/common-issues) - Frequently encountered problems": "[Common Issues](/docs/common-issues) - Frequently encountered problems",
   "[Monitoring and Logging](/docs/monitoring-logging) - Production monitoring setup": "[Monitoring and Logging](/docs/monitoring-logging) - Production monitoring setup"

--- a/i18n/ja/docusaurus-plugin-content-docs/current/error-catalog.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/error-catalog.md
@@ -874,7 +874,7 @@ class CircuitBreaker {
    npm run offline -- --stage dev
    ```
 
-## 関連情報
+## Related Documentation
 
 - [デバッグガイド](/docs/debugging-guide) - 詳細なデバッグ手順
 - [よくある問題](/docs/common-issues) - よく発生する問題

--- a/i18n/ja/translation/error-catalog.json
+++ b/i18n/ja/translation/error-catalog.json
@@ -190,7 +190,7 @@
   "Use request IDs for tracing": "トレーシングには**リクエストID**を使用",
   "Verify environment variables": "環境変数を確認",
   "Test locally with serverless-offline": "serverless-offlineでローカルテスト",
-  "See Also": "関連情報",
+  "Related Documentation": "",
   "[Debugging Guide](/docs/debugging-guide) - Detailed debugging procedures": "[デバッグガイド](/docs/debugging-guide) - 詳細なデバッグ手順",
   "[Common Issues](/docs/common-issues) - Frequently encountered problems": "[よくある問題](/docs/common-issues) - よく発生する問題",
   "[Monitoring and Logging](/docs/monitoring-logging) - Production monitoring setup": "[監視とログ](/docs/monitoring-logging) - 本番監視の設定"


### PR DESCRIPTION
## Summary

`error-catalog.md` の末尾セクション名を `## {{See Also}}` から `## {{Related Documentation}}` に統一しました。

全他のドキュメントでは `Related Documentation` を使用しているため、一貫性を保つための修正です。

## Test plan
- [x] `npm run build` がエラー・警告なしで成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)