### PR TITLE
docs: remove stray TODO placeholders from tsconfig examples

### DIFF
--- a/docs/absolute_imports_and_module_path_aliases.md
+++ b/docs/absolute_imports_and_module_path_aliases.md
@@ -24,7 +24,6 @@ import { Role } from "@/auth/role.enum";
 
 ```json
 # tsconfig.json
-TODO:
 {
   "compilerOptions": {
     "baseUrl": "."
@@ -41,7 +40,6 @@ TODO:
 
 ```json
 # tsconfig.json
- TODO:
 {
   "compilerOptions": {
     "baseUrl": ".",

--- a/i18n/en/docusaurus-plugin-content-docs/current/absolute_imports_and_module_path_aliases.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/absolute_imports_and_module_path_aliases.md
@@ -24,7 +24,6 @@ An example of this configuration:
 
 ```json
 # tsconfig.json
-TODO:
 {
   "compilerOptions": {
     "baseUrl": "."
@@ -41,7 +40,6 @@ For example, the following configuration maps `@/auth/*` to `auth/*`:
 
 ```json
 # tsconfig.json
- TODO:
 {
   "compilerOptions": {
     "baseUrl": ".",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/absolute_imports_and_module_path_aliases.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/absolute_imports_and_module_path_aliases.md
@@ -24,7 +24,6 @@ import { Role } from "@/auth/role.enum";
 
 ```json
 # tsconfig.json
-TODO:
 {
   "compilerOptions": {
     "baseUrl": "."
@@ -42,7 +41,6 @@ TODO:
 
 ```json
 # tsconfig.json
- TODO:
 {
   "compilerOptions": {
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- The **Absolute Imports and Module Path Aliases** guide rendered a literal `TODO:` line inside both `tsconfig.json` JSON code examples, making the samples invalid/confusing.
- Removed the two stray `TODO:` lines from the English source (`docs/absolute_imports_and_module_path_aliases.md`) and regenerated the EN/JA content via `npm run translate:replace-placeholders`.

## Test plan
- [x] `grep -n "TODO"` no longer matches in the EN source or the generated JA page for this doc
- [x] Both `tsconfig.json` examples are now valid JSON object literals
- [ ] Docusaurus build renders the Absolute Imports page without the stray line

🤖 Generated with [Claude Code](https://claude.com/claude-code)