### PR TITLE
docs: fix stale footer copyright year across locales

### DIFF
--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,6 +1,0 @@
-{
-  "copyright": {
-    "message": "Copyright © 2025 Murakami Business Consulting, Inc.",
-    "description": "The footer copyright"
-  }
-}

--- a/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/i18n/ja/docusaurus-theme-classic/footer.json
@@ -1,6 +1,0 @@
-{
-  "copyright": {
-    "message": "Copyright © 2024 Murakami Business Consulting, Inc.",
-    "description": "The footer copyright"
-  }
-}


### PR DESCRIPTION
## Summary
- `docusaurus.config.ts` sets the footer copyright dynamically with `new Date().getFullYear()`, but per-locale theme translation overrides hardcoded the year and had drifted out of sync: **en = 2025**, **ja = 2024**.
- Removed both stale overrides (`i18n/en/docusaurus-theme-classic/footer.json`, `i18n/ja/docusaurus-theme-classic/footer.json`) so both locales fall back to the dynamic config value — self-maintaining, no annual edits needed.

## Test plan
- [x] `npm run build` succeeds for both locales
- [x] EN build (`build/index.html`) footer renders `Copyright © 2026`
- [x] JA build (`build/ja/index.html`) footer renders `Copyright © 2026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)