### PR TITLE
build: remove redundant docusaurus-plugin-llms

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -70,15 +70,6 @@ const config: Config = {
         indexBlog: false,
       },
     ],
-    [
-      'docusaurus-plugin-llms',
-      {
-        generateLLMsTxt: true,
-        generateLLMsFullTxt: true,
-        title: 'MBC CQRS Serverless Framework',
-        description: 'Production-ready CQRS and Event Sourcing framework for building serverless applications on AWS with NestJS, DynamoDB, and other AWS services.',
-      },
-    ],
   ],
   themeConfig: {
     // Replace with your project's social card


### PR DESCRIPTION
## Summary
- `docusaurus-plugin-llms` read the **source** `docs/` directory, where page descriptions are still `{{...}}` placeholders. `gray-matter` parses those as objects, so the plugin crashed with `description.replace is not a function` on ~75 of 78 pages — printing an error line for each on **every build**.
- Its `llms.txt` / `llms-full.txt` output was immediately overwritten by the project's own `scripts/generate-llms-txt.ts`, which is i18n-aware and emits the final EN **and** JA files for all 78 docs. So the plugin was pure redundant build noise.
- Removed the plugin from `docusaurus.config.ts`.

## Test plan
- [x] `npm run build` exits 0
- [x] **0** `description.replace` / `Error processing` lines (was ~75)
- [x] Both Docusaurus locales build (`[SUCCESS]` x2)
- [x] `build/llms.txt` and `build/ja/llms.txt` still list **78** doc links each (unchanged from before)
- [x] No source code touched

## Follow-up (optional)
- The now-unused `docusaurus-plugin-llms` devDependency could be dropped from `package.json` in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)