### PR TITLE
docs: correct stale mbc -h output in CLI reference

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,19 +42,28 @@ mbc -h
 {{The output should look like this:}}
 
 ```bash
-Usage: mbc [options] [command]
+Usage: mbc <command> [options]
 
 Options:
-  -V, --version           output the version number
-  -h, --help              display help for command
+  -v, --version                            Output the current version.
+  -h, --help                               Output usage information.
 
 Commands:
-  new|n [name]            Generate a new CQRS application using the MBC CQRS
-                          serverless framework
-  generate|g <schematic>  Generate a MBC-cqrs-serverless element
-  start|s                 Start application with serverless framework
-  ui-common|ui [options]  add mbc-cqrs-ui-common components to your project
-  help [command]          display help for command
+  new|n [name]                             Generate a new CQRS application using the MBC CQRS serverless framework
+  start|s                                  Start application with serverless framework
+  ui-common|ui [options]                   Add mbc-cqrs-ui-common components to your project.
+  generate|g [options] <schematic> [name]  Generate a MBC-cqrs-serverless element.
+    Schematics available on the collection:
+      ┌────────────┬───────┬──────────────────────┐
+      │ name       │ alias │ description          │
+      │ module     │ mo    │ Create a module.     │
+      │ controller │ co    │ Create a controller. │
+      │ service    │ se    │ Create a service.    │
+      │ entity     │ en    │ Create an entity.    │
+      │ dto        │ dto   │ Create a DTO.        │
+      └────────────┴───────┴──────────────────────┘
+  install-skills|skills [options]          Install Claude Code skills for MBC CQRS Serverless development
+  help [command]                           display help for command
 ```
 
 ## {{new Command}}

--- a/i18n/en/docusaurus-plugin-content-docs/current/cli.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/cli.md
@@ -42,19 +42,28 @@ mbc -h
 The output should look like this:
 
 ```bash
-Usage: mbc [options] [command]
+Usage: mbc <command> [options]
 
 Options:
-  -V, --version           output the version number
-  -h, --help              display help for command
+  -v, --version                            Output the current version.
+  -h, --help                               Output usage information.
 
 Commands:
-  new|n [name]            Generate a new CQRS application using the MBC CQRS
-                          serverless framework
-  generate|g <schematic>  Generate a MBC-cqrs-serverless element
-  start|s                 Start application with serverless framework
-  ui-common|ui [options]  add mbc-cqrs-ui-common components to your project
-  help [command]          display help for command
+  new|n [name]                             Generate a new CQRS application using the MBC CQRS serverless framework
+  start|s                                  Start application with serverless framework
+  ui-common|ui [options]                   Add mbc-cqrs-ui-common components to your project.
+  generate|g [options] <schematic> [name]  Generate a MBC-cqrs-serverless element.
+    Schematics available on the collection:
+      ┌────────────┬───────┬──────────────────────┐
+      │ name       │ alias │ description          │
+      │ module     │ mo    │ Create a module.     │
+      │ controller │ co    │ Create a controller. │
+      │ service    │ se    │ Create a service.    │
+      │ entity     │ en    │ Create an entity.    │
+      │ dto        │ dto   │ Create a DTO.        │
+      └────────────┴───────┴──────────────────────┘
+  install-skills|skills [options]          Install Claude Code skills for MBC CQRS Serverless development
+  help [command]                           display help for command
 ```
 
 ## new Command

--- a/i18n/ja/docusaurus-plugin-content-docs/current/cli.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/cli.md
@@ -42,19 +42,28 @@ mbc -h
 出力は次のようになります：
 
 ```bash
-Usage: mbc [options] [command]
+Usage: mbc <command> [options]
 
 Options:
-  -V, --version           output the version number
-  -h, --help              display help for command
+  -v, --version                            Output the current version.
+  -h, --help                               Output usage information.
 
 Commands:
-  new|n [name]            Generate a new CQRS application using the MBC CQRS
-                          serverless framework
-  generate|g <schematic>  Generate a MBC-cqrs-serverless element
-  start|s                 Start application with serverless framework
-  ui-common|ui [options]  add mbc-cqrs-ui-common components to your project
-  help [command]          display help for command
+  new|n [name]                             Generate a new CQRS application using the MBC CQRS serverless framework
+  start|s                                  Start application with serverless framework
+  ui-common|ui [options]                   Add mbc-cqrs-ui-common components to your project.
+  generate|g [options] <schematic> [name]  Generate a MBC-cqrs-serverless element.
+    Schematics available on the collection:
+      ┌────────────┬───────┬──────────────────────┐
+      │ name       │ alias │ description          │
+      │ module     │ mo    │ Create a module.     │
+      │ controller │ co    │ Create a controller. │
+      │ service    │ se    │ Create a service.    │
+      │ entity     │ en    │ Create an entity.    │
+      │ dto        │ dto   │ Create a DTO.        │
+      └────────────┴───────┴──────────────────────┘
+  install-skills|skills [options]          Install Claude Code skills for MBC CQRS Serverless development
+  help [command]                           display help for command
 ```
 
 ## newコマンド


### PR DESCRIPTION
## Summary
The `mbc -h` output shown in the CLI reference had drifted from the actual built CLI. Verified against `node dist/index.js -h` and corrected:

- **Version flag**: `-V` → `-v`, with the real option descriptions (`Output the current version.` / `Output usage information.`).
- **Command order**: now matches registration order — `new`, `start`, `ui-common`, `generate`, `install-skills`.
- **Missing command**: `install-skills|skills` was absent from the help output entirely (it has its own section below but wasn't in the overview).
- **`generate` entry**: now shows the real signature `[options] <schematic> [name]` plus the "Schematics available on the collection" table.

This is literal code-block content, so EN and JA generated pages get the same corrected output (no translation strings affected).

## Test plan
- [x] Output reproduced from the built CLI (`node dist/index.js -h`, ANSI stripped)
- [x] `npm run build` exits 0, both locales `[SUCCESS]`, no broken links
- [x] EN + JA generated `cli.md` contain the corrected help block
- [x] No framework source modified (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)