### PR TITLE
docs: add migration guide for v1.3.0

### DIFF
--- a/docs/migration/v1.3.0.md
+++ b/docs/migration/v1.3.0.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 3
+description: {{Migration guide for upgrading to MBC CQRS Serverless v1.3.0, including nodemailer v8 upgrade and AppSyncService.sendMessage return type change.}}
+---
+
+# {{Migration Guide: v1.3.0}}
+
+{{This guide helps you upgrade from v1.2.x to v1.3.0. Version 1.3.0 has no breaking changes to application logic, but includes dependency upgrades that may affect test code.}}
+
+## {{Release Date}}
+
+{{2026-05-21}}
+
+## {{Breaking Changes Summary}}
+
+| {{Change}} | {{Impact}} | {{Action Required}} |
+|-----------|----------|-------------------|
+| nodemailer v7 → v8 | {{Error code `NoAuth` renamed to `ENOAUTH`}} | {{Update error handling if `NoAuth` is used}} |
+| `AppSyncService.sendMessage` {{return type}} | {{Changed from `Promise<any>` to `void \| Promise<void>`}} | {{Update test mocks from `null` to `undefined`}} |
+
+## {{Pre-Migration Checklist}}
+
+{{Before upgrading, verify the following:}}
+
+- [ ] {{Check for `'NoAuth'` error code usage in your codebase}}
+- [ ] {{Check for `mockResolvedValue(null)` in AppSyncService.sendMessage mocks}}
+- [ ] {{Run the full test suite after upgrading}}
+
+## {{Breaking Change 1: nodemailer v8 Error Code}}
+
+### {{What Changed}}
+
+nodemailer {{was upgraded from v7 to v8. The error code for authentication failure was renamed:}}
+
+```typescript
+// {{Before (v1.2.x, nodemailer v7)}}
+if (error.code === 'NoAuth') {
+  // handle authentication error
+}
+
+// {{After (v1.3.0, nodemailer v8)}}
+if (error.code === 'ENOAUTH') {
+  // handle authentication error
+}
+```
+
+### {{Migration Steps}}
+
+#### {{Step 1: Find usages}}
+
+```bash
+grep -r "'NoAuth'" --include="*.ts" src/
+grep -r '"NoAuth"' --include="*.ts" src/
+```
+
+#### {{Step 2: Replace if found}}
+
+```bash
+find src/ -name "*.ts" -exec sed -i '' "s/'NoAuth'/'ENOAUTH'/g" {} \;
+```
+
+{{If no results are found, no action is required.}}
+
+## {{Breaking Change 2: AppSyncService.sendMessage Return Type}}
+
+### {{What Changed}}
+
+`AppSyncService.sendMessage` {{return type changed from `Promise<any>` to `void | Promise<void>`. This only affects test code using `mockResolvedValue(null)`.}}
+
+### {{Impact on Tests}}
+
+{{TypeScript will report a compilation error in test files:}}
+
+```
+error TS2345: Argument of type 'null' is not assignable to parameter of type 'void | Promise<void>'.
+```
+
+### {{Migration Steps}}
+
+#### {{Step 1: Find affected test mocks}}
+
+```bash
+grep -r "sendMessage.*mockResolvedValue(null)" --include="*.spec.ts" src/
+grep -r "sendMessage.*mockResolvedValue(null)" --include="*.spec.ts" test/
+```
+
+#### {{Step 2: Replace `null` with `undefined`}}
+
+```bash
+find src/ test/ -name "*.spec.ts" \
+  -exec sed -i '' 's/sendMessage\.mockResolvedValue(null)/sendMessage.mockResolvedValue(undefined)/g' {} \;
+find src/ test/ -name "*.spec.ts" \
+  -exec sed -i '' 's/sendMessage: jest\.fn()\.mockResolvedValue(null)/sendMessage: jest.fn().mockResolvedValue(undefined)/g' {} \;
+```
+
+**{{Before:}}**
+
+```typescript
+// {{Before (v1.2.x)}}
+const mockAppSyncService = {
+  sendMessage: jest.fn().mockResolvedValue(null),
+};
+
+// {{Or inline override}}
+appSyncService.sendMessage.mockResolvedValue(null);
+```
+
+**{{After:}}**
+
+```typescript
+// {{After (v1.3.0)}}
+const mockAppSyncService = {
+  sendMessage: jest.fn().mockResolvedValue(undefined),
+};
+
+// {{Or inline override}}
+appSyncService.sendMessage.mockResolvedValue(undefined);
+```
+
+## {{Upgrade Steps}}
+
+### {{Step 1: Update Dependencies}}
+
+```bash
+npm install \
+  @mbc-cqrs-serverless/core@^1.3.0 \
+  @mbc-cqrs-serverless/tenant@^1.3.0 \
+  @mbc-cqrs-serverless/master@^1.3.0 \
+  @mbc-cqrs-serverless/sequence@^1.3.0 \
+  @mbc-cqrs-serverless/task@^1.3.0 \
+  @mbc-cqrs-serverless/cli@^1.3.0
+```
+
+### {{Step 2: Apply Code Fixes}}
+
+1. {{Fix `NoAuth` → `ENOAUTH` if used (see above)}}
+2. {{Fix `mockResolvedValue(null)` → `mockResolvedValue(undefined)` in AppSyncService mocks}}
+
+### {{Step 3: Run Tests}}
+
+```bash
+npm run test:cov
+```
+
+## {{New Features in v1.3.0}}
+
+- nodemailer v8 {{(improved TLS security, OAuth2 support, SMTP command injection protection)}}
+- {{No new framework APIs}}
+
+## {{Support}}
+
+{{If you encounter issues during migration:}}
+
+- [GitHub Issues](https://github.com/mbc-net/mbc-cqrs-serverless/issues)
+- [{{Documentation}}](https://mbc-cqrs-serverless.mbc-net.com)
+
+## {{Related Documentation}}
+
+- [{{Changelog}}](/docs/changelog)

--- a/i18n/en/docusaurus-plugin-content-docs/current/migration/v1.3.0.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/migration/v1.3.0.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 3
+description: Migration guide for upgrading to MBC CQRS Serverless v1.3.0, including nodemailer v8 upgrade and AppSyncService.sendMessage return type change.
+---
+
+# Migration Guide: v1.3.0
+
+This guide helps you upgrade from v1.2.x to v1.3.0. Version 1.3.0 has no breaking changes to application logic, but includes dependency upgrades that may affect test code.
+
+## Release Date
+
+2026-05-21
+
+## Breaking Changes Summary
+
+| Change | Impact | Action Required |
+|-----------|----------|-------------------|
+| nodemailer v7 → v8 | Error code `NoAuth` renamed to `ENOAUTH` | Update error handling if `NoAuth` is used |
+| `AppSyncService.sendMessage` return type | Changed from `Promise<any>` to `void \| Promise<void>` | Update test mocks from `null` to `undefined` |
+
+## Pre-Migration Checklist
+
+Before upgrading, verify the following:
+
+- [ ] Check for `'NoAuth'` error code usage in your codebase
+- [ ] Check for `mockResolvedValue(null)` in AppSyncService.sendMessage mocks
+- [ ] Run the full test suite after upgrading
+
+## Breaking Change 1: nodemailer v8 Error Code
+
+### What Changed
+
+nodemailer was upgraded from v7 to v8. The error code for authentication failure was renamed:
+
+```typescript
+// Before (v1.2.x, nodemailer v7)
+if (error.code === 'NoAuth') {
+  // handle authentication error
+}
+
+// After (v1.3.0, nodemailer v8)
+if (error.code === 'ENOAUTH') {
+  // handle authentication error
+}
+```
+
+### Migration Steps
+
+#### Step 1: Find usages
+
+```bash
+grep -r "'NoAuth'" --include="*.ts" src/
+grep -r '"NoAuth"' --include="*.ts" src/
+```
+
+#### Step 2: Replace if found
+
+```bash
+find src/ -name "*.ts" -exec sed -i '' "s/'NoAuth'/'ENOAUTH'/g" {} \;
+```
+
+If no results are found, no action is required.
+
+## Breaking Change 2: AppSyncService.sendMessage Return Type
+
+### What Changed
+
+`AppSyncService.sendMessage` return type changed from `Promise<any>` to `void | Promise<void>`. This only affects test code using `mockResolvedValue(null)`.
+
+### Impact on Tests
+
+TypeScript will report a compilation error in test files:
+
+```
+error TS2345: Argument of type 'null' is not assignable to parameter of type 'void | Promise<void>'.
+```
+
+### Migration Steps
+
+#### Step 1: Find affected test mocks
+
+```bash
+grep -r "sendMessage.*mockResolvedValue(null)" --include="*.spec.ts" src/
+grep -r "sendMessage.*mockResolvedValue(null)" --include="*.spec.ts" test/
+```
+
+#### Step 2: Replace `null` with `undefined`
+
+```bash
+find src/ test/ -name "*.spec.ts" \
+  -exec sed -i '' 's/sendMessage\.mockResolvedValue(null)/sendMessage.mockResolvedValue(undefined)/g' {} \;
+find src/ test/ -name "*.spec.ts" \
+  -exec sed -i '' 's/sendMessage: jest\.fn()\.mockResolvedValue(null)/sendMessage: jest.fn().mockResolvedValue(undefined)/g' {} \;
+```
+
+**Before:**
+
+```typescript
+// Before (v1.2.x)
+const mockAppSyncService = {
+  sendMessage: jest.fn().mockResolvedValue(null),
+};
+
+// Or inline override
+appSyncService.sendMessage.mockResolvedValue(null);
+```
+
+**After:**
+
+```typescript
+// After (v1.3.0)
+const mockAppSyncService = {
+  sendMessage: jest.fn().mockResolvedValue(undefined),
+};
+
+// Or inline override
+appSyncService.sendMessage.mockResolvedValue(undefined);
+```
+
+## Upgrade Steps
+
+### Step 1: Update Dependencies
+
+```bash
+npm install \
+  @mbc-cqrs-serverless/core@^1.3.0 \
+  @mbc-cqrs-serverless/tenant@^1.3.0 \
+  @mbc-cqrs-serverless/master@^1.3.0 \
+  @mbc-cqrs-serverless/sequence@^1.3.0 \
+  @mbc-cqrs-serverless/task@^1.3.0 \
+  @mbc-cqrs-serverless/cli@^1.3.0
+```
+
+### Step 2: Apply Code Fixes
+
+1. Fix `NoAuth` → `ENOAUTH` if used (see above)
+2. Fix `mockResolvedValue(null)` → `mockResolvedValue(undefined)` in AppSyncService mocks
+
+### Step 3: Run Tests
+
+```bash
+npm run test:cov
+```
+
+## New Features in v1.3.0
+
+- nodemailer v8 (improved TLS security, OAuth2 support, SMTP command injection protection)
+- No new framework APIs
+
+## Support
+
+If you encounter issues during migration:
+
+- [GitHub Issues](https://github.com/mbc-net/mbc-cqrs-serverless/issues)
+- [Documentation](https://mbc-cqrs-serverless.mbc-net.com)
+
+## Related Documentation
+
+- [Changelog](/docs/changelog)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/migration/v1.3.0.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/migration/v1.3.0.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 3
+description: MBC CQRS Serverless v1.3.0へのアップグレードガイド。nodemailer v8アップグレードとAppSyncService.sendMessage戻り値型の変更を含む。
+---
+
+# マイグレーションガイド: v1.3.0
+
+このガイドはv1.2.xからv1.3.0へのアップグレードを支援します。バージョン1.3.0はアプリケーションロジックに対する破壊的変更はありませんが、テストコードに影響する依存関係のアップグレードが含まれています。
+
+## リリース日
+
+2026-05-21
+
+## 破壊的変更の概要
+
+| 変更内容 | 影響 | 必要なアクション |
+|-----------|----------|-------------------|
+| nodemailer v7 → v8 | エラーコード `NoAuth` が `ENOAUTH` に改名 | `NoAuth` を使用している場合はエラー処理を更新 |
+| `AppSyncService.sendMessage` 戻り値型 | `Promise<any>` から `void \| Promise<void>` に変更 | テストモックを `null` から `undefined` に更新 |
+
+## 移行前チェックリスト
+
+アップグレード前に以下を確認してください：
+
+- [ ] コードベースで `'NoAuth'` エラーコードの使用を確認
+- [ ] AppSyncService.sendMessage モックで `mockResolvedValue(null)` の使用を確認
+- [ ] アップグレード後にフルテストスイートを実行
+
+## 破壊的変更1: nodemailer v8 エラーコード
+
+### 変更内容
+
+nodemailerがv7からv8にアップグレードされました。認証失敗のエラーコードが改名されました：
+
+```typescript
+// Before (v1.2.x, nodemailer v7)
+if (error.code === 'NoAuth') {
+  // handle authentication error
+}
+
+// After (v1.3.0, nodemailer v8)
+if (error.code === 'ENOAUTH') {
+  // handle authentication error
+}
+```
+
+### 移行手順
+
+#### Step 1: 使用箇所を確認
+
+```bash
+grep -r "'NoAuth'" --include="*.ts" src/
+grep -r '"NoAuth"' --include="*.ts" src/
+```
+
+#### Step 2: 見つかった場合は置き換え
+
+```bash
+find src/ -name "*.ts" -exec sed -i '' "s/'NoAuth'/'ENOAUTH'/g" {} \;
+```
+
+検索結果が見つからない場合は、対応不要です。
+
+## 破壊的変更2: AppSyncService.sendMessage 戻り値型
+
+### 変更内容
+
+`AppSyncService.sendMessage` の戻り値型が `Promise<any>` から `void | Promise<void>` に変更されました。この変更は `mockResolvedValue(null)` を使用しているテストコードのみに影響します。
+
+### テストへの影響
+
+テストファイルでTypeScriptのコンパイルエラーが発生します：
+
+```
+error TS2345: Argument of type 'null' is not assignable to parameter of type 'void | Promise<void>'.
+```
+
+### 移行手順
+
+#### Step 1: 影響を受けるテストモックを確認
+
+```bash
+grep -r "sendMessage.*mockResolvedValue(null)" --include="*.spec.ts" src/
+grep -r "sendMessage.*mockResolvedValue(null)" --include="*.spec.ts" test/
+```
+
+#### Step 2: `null` を `undefined` に置き換え
+
+```bash
+find src/ test/ -name "*.spec.ts" \
+  -exec sed -i '' 's/sendMessage\.mockResolvedValue(null)/sendMessage.mockResolvedValue(undefined)/g' {} \;
+find src/ test/ -name "*.spec.ts" \
+  -exec sed -i '' 's/sendMessage: jest\.fn()\.mockResolvedValue(null)/sendMessage: jest.fn().mockResolvedValue(undefined)/g' {} \;
+```
+
+**変更前:**
+
+```typescript
+// Before (v1.2.x)
+const mockAppSyncService = {
+  sendMessage: jest.fn().mockResolvedValue(null),
+};
+
+// インラインオーバーライド
+appSyncService.sendMessage.mockResolvedValue(null);
+```
+
+**変更後:**
+
+```typescript
+// After (v1.3.0)
+const mockAppSyncService = {
+  sendMessage: jest.fn().mockResolvedValue(undefined),
+};
+
+// インラインオーバーライド
+appSyncService.sendMessage.mockResolvedValue(undefined);
+```
+
+## アップグレード手順
+
+### Step 1: 依存関係を更新
+
+```bash
+npm install \
+  @mbc-cqrs-serverless/core@^1.3.0 \
+  @mbc-cqrs-serverless/tenant@^1.3.0 \
+  @mbc-cqrs-serverless/master@^1.3.0 \
+  @mbc-cqrs-serverless/sequence@^1.3.0 \
+  @mbc-cqrs-serverless/task@^1.3.0 \
+  @mbc-cqrs-serverless/cli@^1.3.0
+```
+
+### Step 2: コードの修正を適用
+
+1. 使用している場合は `NoAuth` → `ENOAUTH` を修正（上記参照）
+2. AppSyncService モックの `mockResolvedValue(null)` → `mockResolvedValue(undefined)` を修正
+
+### Step 3: テストを実行
+
+```bash
+npm run test:cov
+```
+
+## v1.3.0 の新機能
+
+- nodemailer v8（TLSセキュリティの強化、OAuth2サポート、SMTPコマンドインジェクション対策）
+- フレームワークAPIへの新規追加なし
+
+## サポート
+
+移行中に問題が発生した場合：
+
+- [GitHub Issues](https://github.com/mbc-net/mbc-cqrs-serverless/issues)
+- [ドキュメント](https://mbc-cqrs-serverless.mbc-net.com)
+
+## 関連ドキュメント
+
+- [変更履歴](/docs/changelog)


### PR DESCRIPTION
- nodemailer v7 → v8: error code 'NoAuth' renamed to 'ENOAUTH'
- AppSyncService.sendMessage return type changed to void | Promise<void>; update test mocks from mockResolvedValue(null) to mockResolvedValue(undefined)

Added in 3 languages: docs/ (template), i18n/en/, i18n/ja/