### PR TITLE
docs: add migration/v1.3.0 to sidebar Migration Guides

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -231,6 +231,7 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Migration Guides",
       items: [
+        "migration/v1.3.0",
         "migration/v1.1.0",
       ],
     },


### PR DESCRIPTION
## Summary
[PR #73](https://github.com/mbc-net/mbc-cqrs-serverless-doc/pull/73) added `docs/migration/v1.3.0.md` (and its EN/JA generated counterparts) but didn't update `sidebars.ts`, so the new guide wasn't reachable from the sidebar (Migration Guides category only listed `v1.1.0`).

Added `migration/v1.3.0` to the Migration Guides items, newest first.

## Test plan
- [x] `npm run build` exits 0, both locales `[SUCCESS]`, no broken links
- [x] Migration Guides category now includes `migration/v1.3.0`
- [x] No source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)