### PR TITLE
docs: improve sidebar learning flow and unify Cognito env var name

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -39,7 +39,7 @@ provider:
     NODE_ENV: ${self:provider.stage}
     APP_NAME: ${self:service}
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
-    COGNITO_CLIENT_ID: ${env:COGNITO_CLIENT_ID}
+    COGNITO_USER_POOL_CLIENT_ID: ${env:COGNITO_USER_POOL_CLIENT_ID}
 
   iam:
     role:
@@ -398,7 +398,7 @@ export default () => ({
 
   auth: {
     userPoolId: process.env.COGNITO_USER_POOL_ID,
-    clientId: process.env.COGNITO_CLIENT_ID,
+    clientId: process.env.COGNITO_USER_POOL_CLIENT_ID,
   },
 
   features: {

--- a/i18n/en/docusaurus-plugin-content-docs/current/configuring.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/configuring.md
@@ -39,7 +39,7 @@ provider:
     NODE_ENV: ${self:provider.stage}
     APP_NAME: ${self:service}
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
-    COGNITO_CLIENT_ID: ${env:COGNITO_CLIENT_ID}
+    COGNITO_USER_POOL_CLIENT_ID: ${env:COGNITO_USER_POOL_CLIENT_ID}
 
   iam:
     role:
@@ -398,7 +398,7 @@ export default () => ({
 
   auth: {
     userPoolId: process.env.COGNITO_USER_POOL_ID,
-    clientId: process.env.COGNITO_CLIENT_ID,
+    clientId: process.env.COGNITO_USER_POOL_CLIENT_ID,
   },
 
   features: {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/configuring.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/configuring.md
@@ -39,7 +39,7 @@ provider:
     NODE_ENV: ${self:provider.stage}
     APP_NAME: ${self:service}
     COGNITO_USER_POOL_ID: ${env:COGNITO_USER_POOL_ID}
-    COGNITO_CLIENT_ID: ${env:COGNITO_CLIENT_ID}
+    COGNITO_USER_POOL_CLIENT_ID: ${env:COGNITO_USER_POOL_CLIENT_ID}
 
   iam:
     role:
@@ -398,7 +398,7 @@ export default () => ({
 
   auth: {
     userPoolId: process.env.COGNITO_USER_POOL_ID,
-    clientId: process.env.COGNITO_CLIENT_ID,
+    clientId: process.env.COGNITO_USER_POOL_CLIENT_ID,
   },
 
   features: {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -64,13 +64,13 @@ const sidebars: SidebarsConfig = {
         "build-your-application",
         "controllers",
         "modules",
+        "service-patterns",
         "event-handling-patterns",
         "data-sync-handler-examples",
-        "service-patterns",
-        "multi-tenant-patterns",
-        "import-export-patterns",
         "api-integration-guide",
+        "multi-tenant-patterns",
         "data-migration-patterns",
+        "import-export-patterns",
       ],
     },
 
@@ -130,9 +130,20 @@ const sidebars: SidebarsConfig = {
       ],
     },
 
+    // 7. Testing - テストガイド（開発ガイドの直後）
+    {
+      type: "category",
+      label: "Testing",
+      link: {
+        type: "doc",
+        id: "testing",
+      },
+      items: ["unit-test", "e2e-test"],
+    },
+
     // === 共通基盤 ===
 
-    // 7. Infrastructure - インフラストラクチャ設定
+    // 8. Infrastructure - インフラストラクチャ設定
     {
       type: "category",
       label: "Infrastructure",
@@ -145,14 +156,14 @@ const sidebars: SidebarsConfig = {
       ],
     },
 
-    // 8. Security - セキュリティガイド
+    // 9. Security - セキュリティガイド
     {
       type: "category",
       label: "Security",
       items: ["security-best-practices", "authentication"],
     },
 
-    // 9. Configuration - 設定ガイド
+    // 10. Configuration - 設定ガイド
     {
       type: "category",
       label: "Configuration",
@@ -164,17 +175,6 @@ const sidebars: SidebarsConfig = {
         "environment-variables",
         "absolute_imports_and_module_path_aliases",
       ],
-    },
-
-    // 10. Testing - テストガイド
-    {
-      type: "category",
-      label: "Testing",
-      link: {
-        type: "doc",
-        id: "testing",
-      },
-      items: ["unit-test", "e2e-test"],
     },
 
     // === 運用 ===


### PR DESCRIPTION
## 概要

サイドバー構成のレビュー結果に基づく学習フロー改善と、ドキュメント間の環境変数名の表記ゆれ修正です。

## 変更内容

### 1. Backend Development セクションの並び順を実装フロー順に変更（sidebars.ts）

SE が実際に実装する順序（Controllers → Services → Events → Data Sync → API連携 → 横断パターン）に合わせました。従来は service-patterns が event-handling / data-sync の後にあり、学習順序が前後していました。

**変更前:** controllers → modules → event-handling → data-sync → service-patterns → multi-tenant → import-export → api-integration → data-migration
**変更後:** controllers → modules → service-patterns → event-handling → data-sync → api-integration → multi-tenant → data-migration → import-export

### 2. Testing セクションを開発セクション直後に移動（sidebars.ts）

開発（Backend / Modules / Frontend）→ テスト → インフラ・設定 → デプロイという自然な流れに変更。従来は Configuration の後にあり、開発→テストの流れが分断されていました。

### 3. Cognito 環境変数名の統一（configuring.md）

`configuring.md` の serverless.yml / 設定サービスの例が `COGNITO_CLIENT_ID` を使用しており、`environment-variables.md` の `COGNITO_USER_POOL_CLIENT_ID` と不一致でした。両例を `COGNITO_USER_POOL_CLIENT_ID` に統一（コードブロック内のため翻訳 JSON の変更は不要、en/ja 両生成ファイルに反映済み）。

## 検証

- `npm run build` をローカルで完走（en/ja 各79ドキュメント、リンク切れ・サイドバーエラーなし）
- `translate:replace-placeholders` 再生成で意図した差分のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)