### PR TITLE
docs: fix stale skExpression typo in examples and document RotateByEnum values

### DIFF
--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -665,7 +665,7 @@ async function getCommandHistory(pk: string, baseSk: string) {
     commandTableName,
     pk,
     {
-      skExpession: 'begins_with(sk, :sk)',
+      skExpression: 'begins_with(sk, :sk)',
       skAttributeValues: { ':sk': `${baseSk}@` },
     },
     undefined,

--- a/docs/key-patterns.md
+++ b/docs/key-patterns.md
@@ -510,7 +510,7 @@ const items = await dataService.listItemsByPk(
   `ORDER${KEY_SEPARATOR}${tenantCode}`,
   {
     sk: {
-      skExpession: 'begins_with(sk, :skPrefix)',
+      skExpression: 'begins_with(sk, :skPrefix)',
       skAttributeValues: { ':skPrefix': `ORDER_ITEM${KEY_SEPARATOR}${orderId}` },
     },
   },
@@ -525,7 +525,7 @@ const items = await dataService.listItemsByPk(
   `ORDER${KEY_SEPARATOR}${tenantCode}`,
   {
     sk: {
-      skExpession: 'sk BETWEEN :start AND :end',
+      skExpression: 'sk BETWEEN :start AND :end',
       skAttributeValues: { ':start': startDate, ':end': endDate },
     },
   },

--- a/docs/sequence.md
+++ b/docs/sequence.md
@@ -95,11 +95,11 @@ export class SeqModule {}
 - {{`rotateBy?: RotateByEnum`}}
   - {{Default: NONE.}}
   - {{Options}}
-    - {{FISCAL_YEARLY}}
-    - {{YEARLY}}
-    - {{MONTHLY}}
-    - {{DAILY}}
-    - {{NONE}}
+    - {{FISCAL_YEARLY}} (`'fiscal_yearly'`)
+    - {{YEARLY}} (`'yearly'`)
+    - {{MONTHLY}} (`'monthly'`)
+    - {{DAILY}} (`'daily'`)
+    - {{NONE}} (`'none'`)
   - {{Description: Determines the rotation type for the sequence.}}
 
 - {{`tenantCode: string`}}

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -346,7 +346,7 @@ const task = await this.taskService.getTask({
 ```ts
 interface ListTaskOptions {
   sk?: {
-    skExpession: string;
+    skExpression: string;
     skAttributeValues: Record<string, string>;
     skAttributeNames?: Record<string, string>;
   };

--- a/i18n/en/docusaurus-plugin-content-docs/current/debugging-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/debugging-guide.md
@@ -665,7 +665,7 @@ async function getCommandHistory(pk: string, baseSk: string) {
     commandTableName,
     pk,
     {
-      skExpession: 'begins_with(sk, :sk)',
+      skExpression: 'begins_with(sk, :sk)',
       skAttributeValues: { ':sk': `${baseSk}@` },
     },
     undefined,

--- a/i18n/en/docusaurus-plugin-content-docs/current/key-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/key-patterns.md
@@ -510,7 +510,7 @@ const items = await dataService.listItemsByPk(
   `ORDER${KEY_SEPARATOR}${tenantCode}`,
   {
     sk: {
-      skExpession: 'begins_with(sk, :skPrefix)',
+      skExpression: 'begins_with(sk, :skPrefix)',
       skAttributeValues: { ':skPrefix': `ORDER_ITEM${KEY_SEPARATOR}${orderId}` },
     },
   },
@@ -525,7 +525,7 @@ const items = await dataService.listItemsByPk(
   `ORDER${KEY_SEPARATOR}${tenantCode}`,
   {
     sk: {
-      skExpession: 'sk BETWEEN :start AND :end',
+      skExpression: 'sk BETWEEN :start AND :end',
       skAttributeValues: { ':start': startDate, ':end': endDate },
     },
   },

--- a/i18n/en/docusaurus-plugin-content-docs/current/sequence.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sequence.md
@@ -95,11 +95,11 @@ The data transfer object that customizes the behavior of the sequence generation
 - `rotateBy?: RotateByEnum`
   - Default: NONE.
   - Options
-    - FISCAL_YEARLY
-    - YEARLY
-    - MONTHLY
-    - DAILY
-    - NONE
+    - FISCAL_YEARLY (`'fiscal_yearly'`)
+    - YEARLY (`'yearly'`)
+    - MONTHLY (`'monthly'`)
+    - DAILY (`'daily'`)
+    - NONE (`'none'`)
   - Description: Determines the rotation type for the sequence.
 
 - `tenantCode: string`

--- a/i18n/en/docusaurus-plugin-content-docs/current/tasks.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tasks.md
@@ -346,7 +346,7 @@ Lists tasks by tenant code and type.
 ```ts
 interface ListTaskOptions {
   sk?: {
-    skExpession: string;
+    skExpression: string;
     skAttributeValues: Record<string, string>;
     skAttributeNames?: Record<string, string>;
   };

--- a/i18n/ja/docusaurus-plugin-content-docs/current/debugging-guide.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/debugging-guide.md
@@ -665,7 +665,7 @@ async function getCommandHistory(pk: string, baseSk: string) {
     commandTableName,
     pk,
     {
-      skExpession: 'begins_with(sk, :sk)',
+      skExpression: 'begins_with(sk, :sk)',
       skAttributeValues: { ':sk': `${baseSk}@` },
     },
     undefined,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/key-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/key-patterns.md
@@ -510,7 +510,7 @@ const items = await dataService.listItemsByPk(
   `ORDER${KEY_SEPARATOR}${tenantCode}`,
   {
     sk: {
-      skExpession: 'begins_with(sk, :skPrefix)',
+      skExpression: 'begins_with(sk, :skPrefix)',
       skAttributeValues: { ':skPrefix': `ORDER_ITEM${KEY_SEPARATOR}${orderId}` },
     },
   },
@@ -525,7 +525,7 @@ const items = await dataService.listItemsByPk(
   `ORDER${KEY_SEPARATOR}${tenantCode}`,
   {
     sk: {
-      skExpession: 'sk BETWEEN :start AND :end',
+      skExpression: 'sk BETWEEN :start AND :end',
       skAttributeValues: { ':start': startDate, ':end': endDate },
     },
   },

--- a/i18n/ja/docusaurus-plugin-content-docs/current/sequence.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/sequence.md
@@ -95,11 +95,11 @@ GenerateFormattedSequenceDto オブジェクトで提供されたパラメータ
 - `rotateBy?: RotateByEnum`
   - デフォルト: NONE。
   - オプション
-    - FISCAL_YEARLY（会計年度）
-    - YEARLY（年次）
-    - MONTHLY（月次）
-    - DAILY（日次）
-    - NONE（採番なし）
+    - FISCAL_YEARLY（会計年度） (`'fiscal_yearly'`)
+    - YEARLY（年次） (`'yearly'`)
+    - MONTHLY（月次） (`'monthly'`)
+    - DAILY（日次） (`'daily'`)
+    - NONE（採番なし） (`'none'`)
   - 説明: シーケンスの回転タイプを決定します。
 
 - `tenantCode: string`

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tasks.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tasks.md
@@ -346,7 +346,7 @@ const task = await this.taskService.getTask({
 ```ts
 interface ListTaskOptions {
   sk?: {
-    skExpession: string;
+    skExpression: string;
     skAttributeValues: Record<string, string>;
     skAttributeNames?: Record<string, string>;
   };


### PR DESCRIPTION
## 概要

モジュール API ドキュメント（master / tenant / sequence / tasks）とフレームワーク実装（origin/main）の突き合わせ調査で発見した、コード例の古いパラメータ名と enum 値の記載不足を修正しました。

## 修正内容

### 1. コード例の `skExpession`（旧タイポ名）を `skExpression` に修正（4箇所）

フレームワーク側では `skExpession` → `skExpression` のリネームが完了しており（チェンジログ記載のタイポ修正、origin/main に旧名は0件）、ドキュメントのコード例だけが旧名のままでした。**コピーして使うと sk 条件が無視されるか型エラーになる**実害のある誤りです：

- `tasks.md` — `ListTaskOptions` インターフェース定義
- `key-patterns.md` — `listItemsByPk` のクエリ例 2箇所
- `debugging-guide.md` — コマンド履歴取得の例

※ `changelog.md` に残る1件は「タイポを修正した」という履歴記述自体のため意図的に保持。

### 2. `RotateByEnum` の実際の文字列値を併記（sequence.md）

オプション一覧に enum キー名のみ記載されており、DynamoDB のアイテムやペイロードに現れる実値が不明でした。実装（`packages/sequence/src/enums/rotate-by.enum.ts`）で確認した値（`'fiscal_yearly'` 等）を併記。

## 調査で確認した正常項目

- master.md / tenant.md の全 public メソッドシグネチャ・DTO は実装と一致（不一致なし）
- `CreateTaskDto.input` の型記載は実装の DTO 宣言（`Record<string, any>`）と異なるものの、Step Functions 用に配列を渡す実用上の契約を正しく案内しているため変更せず（フレームワーク側の型定義課題として申し送り）

## 検証

- 実装は `git show origin/main:...` / `git grep ... origin/main` で直接確認（フレームワークのソースは未変更）
- `translate:replace-placeholders` で en/ja 再生成、未解決 placeholder 0件（enum 値は placeholder 外のため翻訳 JSON 変更不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)