### PR TITLE
docs: replace non-existent CQRS handler decorators and fix core import

### DIFF
--- a/docs/architecture/cqrs-flow.md
+++ b/docs/architecture/cqrs-flow.md
@@ -168,17 +168,18 @@ publishAsync()
 ### {{Command Handler}}
 
 ```typescript
-@CommandHandler(CreateResourceCommand)
-export class CreateResourceHandler
-  implements ICommandHandler<CreateResourceCommand> {
-
+@Injectable()
+export class ResourceService {
   constructor(private readonly commandService: CommandService) {}
 
-  async execute(command: CreateResourceCommand): Promise<DataEntity> {
+  async create(
+    dto: CreateResourceDto,
+    invokeContext: IInvoke,
+  ): Promise<CommandModel | null> {
     // 1. Validate business rules
-    // 2. Create entity
+    // 2. Build the command input (pk, sk, attributes, ...)
     // 3. Persist and publish event
-    return this.commandService.publishAsync(entity, { invokeContext });
+    return this.commandService.publishAsync(input, { invokeContext });
   }
 }
 ```
@@ -186,17 +187,12 @@ export class CreateResourceHandler
 ### {{Query Handler}}
 
 ```typescript
-@QueryHandler(GetResourceQuery)
-export class GetResourceHandler
-  implements IQueryHandler<GetResourceQuery> {
-
+@Injectable()
+export class ResourceQueryService {
   constructor(private readonly dataService: DataService) {}
 
-  async execute(query: GetResourceQuery): Promise<DataEntity> {
-    return this.dataService.getItem({
-      pk: query.pk,
-      sk: query.sk,
-    });
+  async findOne(pk: string, sk: string): Promise<DataModel> {
+    return this.dataService.getItem({ pk, sk });
   }
 }
 ```

--- a/docs/build-todo-app.md
+++ b/docs/build-todo-app.md
@@ -457,7 +457,8 @@ export class TodoModule {}
 {{Add `findOne` method to `todo.service.ts`:}}
 
 ```typescript
-import { DataService, NotFoundException } from '@mbc-cqrs-serverless/core'
+import { DataService } from '@mbc-cqrs-serverless/core'
+import { NotFoundException } from '@nestjs/common'
 
 @Injectable()
 export class TodoService {

--- a/i18n/en/docusaurus-plugin-content-docs/current/architecture/cqrs-flow.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/architecture/cqrs-flow.md
@@ -168,17 +168,18 @@ See the [Read-Your-Writes implementation guide](/docs/command-service#read-your-
 ### Command Handler
 
 ```typescript
-@CommandHandler(CreateResourceCommand)
-export class CreateResourceHandler
-  implements ICommandHandler<CreateResourceCommand> {
-
+@Injectable()
+export class ResourceService {
   constructor(private readonly commandService: CommandService) {}
 
-  async execute(command: CreateResourceCommand): Promise<DataEntity> {
+  async create(
+    dto: CreateResourceDto,
+    invokeContext: IInvoke,
+  ): Promise<CommandModel | null> {
     // 1. Validate business rules
-    // 2. Create entity
+    // 2. Build the command input (pk, sk, attributes, ...)
     // 3. Persist and publish event
-    return this.commandService.publishAsync(entity, { invokeContext });
+    return this.commandService.publishAsync(input, { invokeContext });
   }
 }
 ```
@@ -186,17 +187,12 @@ export class CreateResourceHandler
 ### Query Handler
 
 ```typescript
-@QueryHandler(GetResourceQuery)
-export class GetResourceHandler
-  implements IQueryHandler<GetResourceQuery> {
-
+@Injectable()
+export class ResourceQueryService {
   constructor(private readonly dataService: DataService) {}
 
-  async execute(query: GetResourceQuery): Promise<DataEntity> {
-    return this.dataService.getItem({
-      pk: query.pk,
-      sk: query.sk,
-    });
+  async findOne(pk: string, sk: string): Promise<DataModel> {
+    return this.dataService.getItem({ pk, sk });
   }
 }
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/build-todo-app.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/build-todo-app.md
@@ -457,7 +457,8 @@ Add methods to retrieve single items from DynamoDB.
 Add `findOne` method to `todo.service.ts`:
 
 ```typescript
-import { DataService, NotFoundException } from '@mbc-cqrs-serverless/core'
+import { DataService } from '@mbc-cqrs-serverless/core'
+import { NotFoundException } from '@nestjs/common'
 
 @Injectable()
 export class TodoService {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/architecture/cqrs-flow.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/architecture/cqrs-flow.md
@@ -168,17 +168,18 @@ Read-Your-Writesサポート（`SessionService`、`Repository`）は [v1.2.0](/d
 ### コマンドハンドラー
 
 ```typescript
-@CommandHandler(CreateResourceCommand)
-export class CreateResourceHandler
-  implements ICommandHandler<CreateResourceCommand> {
-
+@Injectable()
+export class ResourceService {
   constructor(private readonly commandService: CommandService) {}
 
-  async execute(command: CreateResourceCommand): Promise<DataEntity> {
+  async create(
+    dto: CreateResourceDto,
+    invokeContext: IInvoke,
+  ): Promise<CommandModel | null> {
     // 1. Validate business rules
-    // 2. Create entity
+    // 2. Build the command input (pk, sk, attributes, ...)
     // 3. Persist and publish event
-    return this.commandService.publishAsync(entity, { invokeContext });
+    return this.commandService.publishAsync(input, { invokeContext });
   }
 }
 ```
@@ -186,17 +187,12 @@ export class CreateResourceHandler
 ### クエリハンドラー
 
 ```typescript
-@QueryHandler(GetResourceQuery)
-export class GetResourceHandler
-  implements IQueryHandler<GetResourceQuery> {
-
+@Injectable()
+export class ResourceQueryService {
   constructor(private readonly dataService: DataService) {}
 
-  async execute(query: GetResourceQuery): Promise<DataEntity> {
-    return this.dataService.getItem({
-      pk: query.pk,
-      sk: query.sk,
-    });
+  async findOne(pk: string, sk: string): Promise<DataModel> {
+    return this.dataService.getItem({ pk, sk });
   }
 }
 ```

--- a/i18n/ja/docusaurus-plugin-content-docs/current/build-todo-app.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/build-todo-app.md
@@ -457,7 +457,8 @@ DynamoDBから単一アイテムを取得するメソッドを追加します。
 `todo.service.ts`に`findOne`メソッドを追加：
 
 ```typescript
-import { DataService, NotFoundException } from '@mbc-cqrs-serverless/core'
+import { DataService } from '@mbc-cqrs-serverless/core'
+import { NotFoundException } from '@nestjs/common'
 
 @Injectable()
 export class TodoService {


### PR DESCRIPTION
## 概要

architecture 系ドキュメントと build-todo-app チュートリアルのコード例を origin/main の実装と突き合わせ、**コンパイル不能なコード例2件**を修正しました。

## 修正内容

### 1. cqrs-flow.md — フレームワークに存在しないデコレータを使用した例

「Key Components」セクションの Command/Query Handler 例が `@nestjs/cqrs` 流の `@CommandHandler` / `@QueryHandler` / `ICommandHandler` / `IQueryHandler` を使用していましたが、これらは `@mbc-cqrs-serverless/core` に存在しません（実在するのは `@EventHandler`、`@DataSyncHandler` 等）。このフレームワークの実際のパターン（`@Injectable` サービスに `CommandService` / `DataService` を注入、戻り値型も実装どおり `CommandModel | null` / `DataModel`）に書き換えました。チュートリアルや他ドキュメントとも整合します。

### 2. build-todo-app.md — `NotFoundException` の import 元誤り

`@mbc-cqrs-serverless/core` から import していましたが、core はこれを export していません（正：`@nestjs/common`。同チュートリアルのテストセクションでは正しく import 済み）。コピーしてもコンパイルできないコードでした。

## 調査で確認した正常項目（変更なし）

- build-todo-app.md のその他40項目以上（クラス・メソッド・デコレータ・npm スクリプト・シグネチャ）は実装と一致
- step-functions.md のステートマシンステップ名は実装と完全一致
- SNS フィルター値（task-execute / command-status 等）は実装と一致

## 申し送り（次回イテレーション候補）

- cdk-infrastructure.md の SNS→SQS subscription コード例がテンプレートの4 subscription 中3つのみ記載（sub-task-status 欠落）、`rawMessageDelivery: true` の付与が不統一 — 図とは整合しているため中優先度として次回対応予定

## 検証

- 実装は `git show origin/main:...` / `git grep ... origin/main` で直接確認（フレームワークのソースは未変更）
- コードブロック内のみの変更のため翻訳 JSON 変更不要、en/ja 再生成済み・未解決 placeholder 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)