### PR TITLE
docs: align CDK SNS→SQS subscription example with project template

### DIFF
--- a/docs/architecture/cdk-infrastructure.md
+++ b/docs/architecture/cdk-infrastructure.md
@@ -380,6 +380,11 @@ const notificationQueue = new sqs.Queue(this, 'NotificationQueue', {
   queueName: `${env}-${appName}-notification-queue`,
 });
 
+// {{Create Sub-task Status Queue}}
+const subTaskStatusQueue = new sqs.Queue(this, 'SubTaskStatusQueue', {
+  queueName: `${env}-${appName}-sub-task-status-queue`,
+});
+
 // {{Create Import Queue}}
 const importQueue = new sqs.Queue(this, 'ImportQueue', {
   queueName: `${env}-${appName}-import-action-queue`,
@@ -393,6 +398,7 @@ mainSnsTopic.addSubscription(
         allowlist: ['task-execute'],
       }),
     },
+    rawMessageDelivery: true,
   })
 );
 
@@ -408,12 +414,24 @@ mainSnsTopic.addSubscription(
 );
 
 mainSnsTopic.addSubscription(
+  new subscriptions.SqsSubscription(subTaskStatusQueue, {
+    filterPolicy: {
+      action: sns.SubscriptionFilter.stringFilter({
+        allowlist: ['sub-task-status'],
+      }),
+    },
+    rawMessageDelivery: true,
+  })
+);
+
+mainSnsTopic.addSubscription(
   new subscriptions.SqsSubscription(importQueue, {
     filterPolicy: {
       action: sns.SubscriptionFilter.stringFilter({
         allowlist: ['import-execute'],
       }),
     },
+    rawMessageDelivery: true,
   })
 );
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/architecture/cdk-infrastructure.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/architecture/cdk-infrastructure.md
@@ -380,6 +380,11 @@ const notificationQueue = new sqs.Queue(this, 'NotificationQueue', {
   queueName: `${env}-${appName}-notification-queue`,
 });
 
+// Create Sub-task Status Queue
+const subTaskStatusQueue = new sqs.Queue(this, 'SubTaskStatusQueue', {
+  queueName: `${env}-${appName}-sub-task-status-queue`,
+});
+
 // Create Import Queue
 const importQueue = new sqs.Queue(this, 'ImportQueue', {
   queueName: `${env}-${appName}-import-action-queue`,
@@ -393,6 +398,7 @@ mainSnsTopic.addSubscription(
         allowlist: ['task-execute'],
       }),
     },
+    rawMessageDelivery: true,
   })
 );
 
@@ -408,12 +414,24 @@ mainSnsTopic.addSubscription(
 );
 
 mainSnsTopic.addSubscription(
+  new subscriptions.SqsSubscription(subTaskStatusQueue, {
+    filterPolicy: {
+      action: sns.SubscriptionFilter.stringFilter({
+        allowlist: ['sub-task-status'],
+      }),
+    },
+    rawMessageDelivery: true,
+  })
+);
+
+mainSnsTopic.addSubscription(
   new subscriptions.SqsSubscription(importQueue, {
     filterPolicy: {
       action: sns.SubscriptionFilter.stringFilter({
         allowlist: ['import-execute'],
       }),
     },
+    rawMessageDelivery: true,
   })
 );
 ```

--- a/i18n/en/translation/architecture/cdk-infrastructure.json
+++ b/i18n/en/translation/architecture/cdk-infrastructure.json
@@ -77,6 +77,7 @@
   "Create Dead Letter Queue": "Create Dead Letter Queue",
   "Create Task Queue with DLQ": "Create Task Queue with DLQ",
   "Create Notification Queue": "Create Notification Queue",
+  "Create Sub-task Status Queue": "Create Sub-task Status Queue",
   "Create Import Queue": "Create Import Queue",
   "Subscribe queues with message filtering": "Subscribe queues with message filtering",
   "DynamoDB attributes bucket": "DynamoDB attributes bucket",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/architecture/cdk-infrastructure.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/architecture/cdk-infrastructure.md
@@ -380,6 +380,11 @@ const notificationQueue = new sqs.Queue(this, 'NotificationQueue', {
   queueName: `${env}-${appName}-notification-queue`,
 });
 
+// Create Sub-task Status Queue (サブタスクステータスキューを作成)
+const subTaskStatusQueue = new sqs.Queue(this, 'SubTaskStatusQueue', {
+  queueName: `${env}-${appName}-sub-task-status-queue`,
+});
+
 // インポートキューを作成
 const importQueue = new sqs.Queue(this, 'ImportQueue', {
   queueName: `${env}-${appName}-import-action-queue`,
@@ -393,6 +398,7 @@ mainSnsTopic.addSubscription(
         allowlist: ['task-execute'],
       }),
     },
+    rawMessageDelivery: true,
   })
 );
 
@@ -408,12 +414,24 @@ mainSnsTopic.addSubscription(
 );
 
 mainSnsTopic.addSubscription(
+  new subscriptions.SqsSubscription(subTaskStatusQueue, {
+    filterPolicy: {
+      action: sns.SubscriptionFilter.stringFilter({
+        allowlist: ['sub-task-status'],
+      }),
+    },
+    rawMessageDelivery: true,
+  })
+);
+
+mainSnsTopic.addSubscription(
   new subscriptions.SqsSubscription(importQueue, {
     filterPolicy: {
       action: sns.SubscriptionFilter.stringFilter({
         allowlist: ['import-execute'],
       }),
     },
+    rawMessageDelivery: true,
   })
 );
 ```

--- a/i18n/ja/translation/architecture/cdk-infrastructure.json
+++ b/i18n/ja/translation/architecture/cdk-infrastructure.json
@@ -77,6 +77,7 @@
   "Create Dead Letter Queue": "デッドレターキューを作成",
   "Create Task Queue with DLQ": "DLQ付きタスクキューを作成",
   "Create Notification Queue": "通知キューを作成",
+  "Create Sub-task Status Queue": "Create Sub-task Status Queue (サブタスクステータスキューを作成)",
   "Create Import Queue": "インポートキューを作成",
   "Subscribe queues with message filtering": "メッセージフィルタリングでキューをサブスクライブ",
   "DynamoDB attributes bucket": "DynamoDB属性バケット",


### PR DESCRIPTION
## 概要

前回 PR #83 で申し送りした cdk-infrastructure.md の CDK コード例を、生成プロジェクトのテンプレート（`packages/cli/templates/infra/libs/infra-stack.ts`）と一致させました。

## 修正内容

- **sub-task-status キューの欠落** — 同ページのルーティング図には `action = 'sub-task-status'` フィルタが描かれているのに、コード例にはキュー作成も subscription もありませんでした（テンプレートの4 subscription 中3つのみ記載）。キュー作成と subscription を追加。
- **`rawMessageDelivery: true` の不統一** — テンプレートは main トピックの全 subscription に設定していますが、コード例では notification のみでした。全 subscription に統一。

## 検証

- テンプレートは `git show origin/main:packages/cli/templates/infra/libs/infra-stack.ts` で直接確認（フレームワークのソースは未変更）
- 新規コードコメント1件の en/ja 翻訳を追加、再生成後の未解決 placeholder 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)