### PR TITLE
docs: fix non-existent listItemsByPk option and document group-roles fields

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -210,9 +210,11 @@ const claims = getAuthorizerClaims(invokeContext);
 
 ```ts
 class UserContext {
-  userId: string;      // {{User's unique identifier (sub claim)}}
-  tenantCode: string;  // {{Current tenant code}}
-  tenantRole: string;  // {{User's role in the current tenant}}
+  userId: string;            // {{User's unique identifier (sub claim)}}
+  tenantCode: string;        // {{Current tenant code}}
+  tenantRole: string;        // {{User's role in the current tenant}}
+  tenantRoles: string[];     // {{Direct roles for the active tenant (excludes group-derived roles)}}
+  tenantGroupIds: string[];  // {{Group IDs from custom:groups for the active tenant}}
 
   constructor(partial: Partial<UserContext>);
 }

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -205,6 +205,7 @@ export interface JwtClaims {
   name: string                       // {{User's display name}}
   'custom:tenant'?: string           // {{Custom claim for tenant code}}
   'custom:roles'?: string            // {{Custom claim for roles JSON array}}
+  'custom:groups'?: string           // {{Custom claim for tenant group memberships JSON array}}
   exp: number                        // {{Token expiration timestamp}}
   email: string
   email_verified?: boolean
@@ -227,9 +228,11 @@ export interface JwtClaims {
 
 ```ts
 export class UserContext {
-  userId: string      // Cognito user ID (from JWT sub claim)
-  tenantRole: string  // User's role within the tenant
-  tenantCode: string  // Current tenant code
+  userId: string             // Cognito user ID (from JWT sub claim)
+  tenantRole: string         // User's role within the tenant
+  tenantCode: string         // Current tenant code
+  tenantRoles: string[]      // {{Direct roles for the active tenant (excludes group-derived roles)}}
+  tenantGroupIds: string[]   // {{Group IDs from custom:groups for the active tenant}}
 
   constructor(partial: Partial<UserContext>)  // {{Initialize with partial properties}}
 }
@@ -266,6 +269,7 @@ export interface CommandModel extends CommandInputModel {
   createdIp?: string    // {{IP address of the creator}}
   updatedIp?: string    // {{IP address of the last updater}}
   taskToken?: string    // {{Step Functions task token for async workflows}}
+  syncMode?: CommandSyncMode  // {{'SYNC' when the command was applied via synchronous publish}}
 }
 ```
 

--- a/docs/key-patterns.md
+++ b/docs/key-patterns.md
@@ -91,7 +91,8 @@ ID = PK#SK (without version)
 | `VER_SEPARATOR` | `@` | {{Separates sort key from version number}} |
 | `VERSION_FIRST` | `0` | {{Initial version for new entities}} |
 | `VERSION_LATEST` | `-1` | {{Indicates query for latest version}} |
-| `TENANT_COMMON` | `common` | {{Tenant code for shared/cross-tenant data}} |
+| `TENANT_COMMON` | `common` | {{Tenant code for shared/cross-tenant data (deprecated — use DEFAULT_COMMON_TENANT_CODES)}} |
+| `DEFAULT_COMMON_TENANT_CODES` | `['common']` | {{Common tenant codes list, configurable via COMMON_TENANT_CODES env var}} |
 | `DEFAULT_TENANT_CODE` | `single` | {{Default tenant for single-tenant mode}} |
 
 :::tip {{Consistent Tenant Code Format}}

--- a/docs/multi-tenant-patterns.md
+++ b/docs/multi-tenant-patterns.md
@@ -240,10 +240,8 @@ export class UserService {
   async getUserTenants(userCode: string): Promise<UserTenantAssociation[]> {
     const pk = `USER_TENANT${KEY_SEPARATOR}${COMMON_TENANT}`;
 
-    // {{Query with SK prefix to find all tenant associations}}
-    const result = await this.dataService.listItemsByPk(pk, {
-      skPrefix: '', // Get all, then filter
-    });
+    // {{List all items under the PK, then filter by user code}}
+    const result = await this.dataService.listItemsByPk(pk);
 
     return result.items.filter(item =>
       item.sk.endsWith(`${KEY_SEPARATOR}${userCode}`),

--- a/docs/service-patterns.md
+++ b/docs/service-patterns.md
@@ -360,7 +360,8 @@ export class ProductService {
       invokeContext: opts.invokeContext,
     });
 
-    return new ProductDataEntity(item);
+    // {{publishAsync returns null when the command is not dirty (no-op)}}
+    return item ? new ProductDataEntity(item) : null;
   }
 
   /**

--- a/i18n/en/docusaurus-plugin-content-docs/current/helpers.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/helpers.md
@@ -210,9 +210,11 @@ const claims = getAuthorizerClaims(invokeContext);
 
 ```ts
 class UserContext {
-  userId: string;      // User's unique identifier (sub claim)
-  tenantCode: string;  // Current tenant code
-  tenantRole: string;  // User's role in the current tenant
+  userId: string;            // User's unique identifier (sub claim)
+  tenantCode: string;        // Current tenant code
+  tenantRole: string;        // User's role in the current tenant
+  tenantRoles: string[];     // Direct roles for the active tenant (excludes group-derived roles)
+  tenantGroupIds: string[];  // Group IDs from custom:groups for the active tenant
 
   constructor(partial: Partial<UserContext>);
 }

--- a/i18n/en/docusaurus-plugin-content-docs/current/interfaces.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/interfaces.md
@@ -205,6 +205,7 @@ export interface JwtClaims {
   name: string                       // User's display name
   'custom:tenant'?: string           // Custom claim for tenant code
   'custom:roles'?: string            // Custom claim for roles JSON array
+  'custom:groups'?: string           // Custom claim for tenant group memberships JSON array
   exp: number                        // Token expiration timestamp
   email: string
   email_verified?: boolean
@@ -227,9 +228,11 @@ User context class extracted from authentication token.
 
 ```ts
 export class UserContext {
-  userId: string      // Cognito user ID (from JWT sub claim)
-  tenantRole: string  // User's role within the tenant
-  tenantCode: string  // Current tenant code
+  userId: string             // Cognito user ID (from JWT sub claim)
+  tenantRole: string         // User's role within the tenant
+  tenantCode: string         // Current tenant code
+  tenantRoles: string[]      // Direct roles for the active tenant (excludes group-derived roles)
+  tenantGroupIds: string[]   // Group IDs from custom:groups for the active tenant
 
   constructor(partial: Partial<UserContext>)  // Initialize with partial properties
 }
@@ -266,6 +269,7 @@ export interface CommandModel extends CommandInputModel {
   createdIp?: string    // IP address of the creator
   updatedIp?: string    // IP address of the last updater
   taskToken?: string    // Step Functions task token for async workflows
+  syncMode?: CommandSyncMode  // 'SYNC' when the command was applied via synchronous publish
 }
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/key-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/key-patterns.md
@@ -91,7 +91,8 @@ The framework provides these constants in `@mbc-cqrs-serverless/core`:
 | `VER_SEPARATOR` | `@` | Separates sort key from version number |
 | `VERSION_FIRST` | `0` | Initial version for new entities |
 | `VERSION_LATEST` | `-1` | Indicates query for latest version |
-| `TENANT_COMMON` | `common` | Tenant code for shared/cross-tenant data |
+| `TENANT_COMMON` | `common` | Tenant code for shared/cross-tenant data (deprecated — use DEFAULT_COMMON_TENANT_CODES) |
+| `DEFAULT_COMMON_TENANT_CODES` | `['common']` | Common tenant codes list, configurable via COMMON_TENANT_CODES env var |
 | `DEFAULT_TENANT_CODE` | `single` | Default tenant for single-tenant mode |
 
 :::tip Consistent Tenant Code Format

--- a/i18n/en/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
@@ -240,10 +240,8 @@ export class UserService {
   async getUserTenants(userCode: string): Promise<UserTenantAssociation[]> {
     const pk = `USER_TENANT${KEY_SEPARATOR}${COMMON_TENANT}`;
 
-    // Query with SK prefix to find all tenant associations
-    const result = await this.dataService.listItemsByPk(pk, {
-      skPrefix: '', // Get all, then filter
-    });
+    // List all items under the PK, then filter by user code
+    const result = await this.dataService.listItemsByPk(pk);
 
     return result.items.filter(item =>
       item.sk.endsWith(`${KEY_SEPARATOR}${userCode}`),

--- a/i18n/en/docusaurus-plugin-content-docs/current/service-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/service-patterns.md
@@ -360,7 +360,8 @@ export class ProductService {
       invokeContext: opts.invokeContext,
     });
 
-    return new ProductDataEntity(item);
+    // publishAsync returns null when the command is not dirty (no-op)
+    return item ? new ProductDataEntity(item) : null;
   }
 
   /**

--- a/i18n/en/translation/helpers.json
+++ b/i18n/en/translation/helpers.json
@@ -14,7 +14,6 @@
   "Generates a unique ID by combining partition key and sort key (without version).": "Generates a unique ID by combining partition key and sort key (without version).",
   "Result: 'TENANT#mbc#CAT#001'": "Result: 'TENANT#mbc#CAT#001'",
   "The inverse of `generateId`: extracts the base sort key from a composite ID. Returns `undefined` if the ID does not start with the given partition key.": "The inverse of `generateId`: extracts the base sort key from a composite ID. Returns `undefined` if the ID does not start with the given partition key.",
-  "Result: 'CAT#001'": "Result: 'CAT#001'",
   "Splits a composite ID back into its partition key and base sort key, assuming the partition key has two segments (type and tenant code). Returns `undefined` if the ID has fewer than three segments.": "Splits a composite ID back into its partition key and base sort key, assuming the partition key has two segments (type and tenant code). Returns `undefined` if the ID has fewer than three segments.",
   "result.pk is 'TENANT#mbc' and result.skBase is 'CAT#001'": "result.pk is 'TENANT#mbc' and result.skBase is 'CAT#001'",
   "Extracts the tenant code from a partition key.": "Extracts the tenant code from a partition key.",
@@ -119,5 +118,7 @@
   "Command Service": "Command Service",
   "Using key helpers": "Using key helpers",
   "Interfaces": "Interfaces",
-  "UserContext and IInvoke interfaces": "UserContext and IInvoke interfaces"
+  "UserContext and IInvoke interfaces": "UserContext and IInvoke interfaces",
+  "Direct roles for the active tenant (excludes group-derived roles)": "Direct roles for the active tenant (excludes group-derived roles)",
+  "Group IDs from custom:groups for the active tenant": "Group IDs from custom:groups for the active tenant"
 }

--- a/i18n/en/translation/interfaces.json
+++ b/i18n/en/translation/interfaces.json
@@ -115,5 +115,9 @@
   "Entity Patterns": "Entity Patterns",
   "Designing entities": "Designing entities",
   "Error Catalog": "Error Catalog",
-  "Error handling": "Error handling"
+  "Error handling": "Error handling",
+  "Custom claim for tenant group memberships JSON array": "Custom claim for tenant group memberships JSON array",
+  "Direct roles for the active tenant (excludes group-derived roles)": "Direct roles for the active tenant (excludes group-derived roles)",
+  "Group IDs from custom:groups for the active tenant": "Group IDs from custom:groups for the active tenant",
+  "'SYNC' when the command was applied via synchronous publish": "'SYNC' when the command was applied via synchronous publish"
 }

--- a/i18n/en/translation/key-patterns.json
+++ b/i18n/en/translation/key-patterns.json
@@ -71,7 +71,7 @@
   "Separates sort key from version number": "Separates sort key from version number",
   "Initial version for new entities": "Initial version for new entities",
   "Indicates query for latest version": "Indicates query for latest version",
-  "Tenant code for shared/cross-tenant data": "Tenant code for shared/cross-tenant data",
+  "Tenant code for shared/cross-tenant data (deprecated — use DEFAULT_COMMON_TENANT_CODES)": "Tenant code for shared/cross-tenant data (deprecated — use DEFAULT_COMMON_TENANT_CODES)",
   "Default tenant for single-tenant mode": "Default tenant for single-tenant mode",
   "Consistent Tenant Code Format": "Consistent Tenant Code Format",
   "The `@mbc-cqrs-serverless/master` and `@mbc-cqrs-serverless/tenant` packages use `SettingTypeEnum.TENANT_COMMON = 'common'` (lowercase), which is consistent with the tenant code normalization in `getUserContext()`. This ensures that data saved by `createCommonTenantSetting()` or `createCommonTenant()` methods can be correctly queried.": "The `@mbc-cqrs-serverless/master` and `@mbc-cqrs-serverless/tenant` packages use `SettingTypeEnum.TENANT_COMMON = 'common'` (lowercase), which is consistent with the tenant code normalization in `getUserContext()`. This ensures that data saved by `createCommonTenantSetting()` or `createCommonTenant()` methods can be correctly queried.",
@@ -210,5 +210,6 @@
   "Use when creating new entities": "Use when creating new entities",
   "Returned when SK has no version": "Returned when SK has no version",
   "Use for cross-tenant shared data": "Use for cross-tenant shared data",
-  "Default for single-tenant mode": "Default for single-tenant mode"
+  "Default for single-tenant mode": "Default for single-tenant mode",
+  "Common tenant codes list, configurable via COMMON_TENANT_CODES env var": "Common tenant codes list, configurable via COMMON_TENANT_CODES env var"
 }

--- a/i18n/en/translation/multi-tenant-patterns.json
+++ b/i18n/en/translation/multi-tenant-patterns.json
@@ -49,7 +49,7 @@
   "Pattern 3: User-Tenant Association": "Pattern 3: User-Tenant Association",
   "Handle users belonging to multiple tenants:": "Handle users belonging to multiple tenants:",
   "Get all tenants a user belongs to": "Get all tenants a user belongs to",
-  "Query with SK prefix to find all tenant associations": "Query with SK prefix to find all tenant associations",
+  "List all items under the PK, then filter by user code": "List all items under the PK, then filter by user code",
   "Add user to tenant": "Add user to tenant",
   "Switch user's active tenant": "Switch user's active tenant",
   "Verify user belongs to tenant": "Verify user belongs to tenant",

--- a/i18n/en/translation/service-patterns.json
+++ b/i18n/en/translation/service-patterns.json
@@ -110,5 +110,6 @@
   "Data Service": "Data Service",
   "DataService query methods": "DataService query methods",
   "Database Selection Guide": "Database Selection Guide",
-  "DynamoDB vs RDS": "DynamoDB vs RDS"
+  "DynamoDB vs RDS": "DynamoDB vs RDS",
+  "publishAsync returns null when the command is not dirty (no-op)": "publishAsync returns null when the command is not dirty (no-op)"
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/helpers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/helpers.md
@@ -210,9 +210,11 @@ const claims = getAuthorizerClaims(invokeContext);
 
 ```ts
 class UserContext {
-  userId: string;      // ユーザーの一意識別子（subクレーム）
-  tenantCode: string;  // 現在のテナントコード
-  tenantRole: string;  // 現在のテナントでのユーザーの役割
+  userId: string;            // ユーザーの一意識別子（subクレーム）
+  tenantCode: string;        // 現在のテナントコード
+  tenantRole: string;        // 現在のテナントでのユーザーの役割
+  tenantRoles: string[];     // Direct roles for the active tenant (アクティブテナントの直接ロール、グループ由来ロールを除く)
+  tenantGroupIds: string[];  // Group IDs from custom:groups for the active tenant (custom:groups由来のグループID)
 
   constructor(partial: Partial<UserContext>);
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/interfaces.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/interfaces.md
@@ -205,6 +205,7 @@ export interface JwtClaims {
   name: string                       // User's display name (ユーザー表示名)
   'custom:tenant'?: string           // Custom claim for tenant code (テナントコード用カスタムクレーム)
   'custom:roles'?: string            // Custom claim for roles JSON array (ロールJSON配列用カスタムクレーム)
+  'custom:groups'?: string           // Custom claim for tenant group memberships JSON array (テナントグループ所属のJSON配列カスタムクレーム)
   exp: number                        // Token expiration timestamp (トークン有効期限タイムスタンプ)
   email: string
   email_verified?: boolean
@@ -227,9 +228,11 @@ export interface JwtClaims {
 
 ```ts
 export class UserContext {
-  userId: string      // Cognito user ID (from JWT sub claim)
-  tenantRole: string  // User's role within the tenant
-  tenantCode: string  // Current tenant code
+  userId: string             // Cognito user ID (from JWT sub claim)
+  tenantRole: string         // User's role within the tenant
+  tenantCode: string         // Current tenant code
+  tenantRoles: string[]      // Direct roles for the active tenant (アクティブテナントの直接ロール、グループ由来ロールを除く)
+  tenantGroupIds: string[]   // Group IDs from custom:groups for the active tenant (custom:groups由来のグループID)
 
   constructor(partial: Partial<UserContext>)  // Initialize with partial properties (部分的なプロパティで初期化)
 }
@@ -266,6 +269,7 @@ export interface CommandModel extends CommandInputModel {
   createdIp?: string    // IP address of the creator (作成者のIPアドレス)
   updatedIp?: string    // IP address of the last updater (最終更新者のIPアドレス)
   taskToken?: string    // Step Functions task token for async workflows (非同期ワークフロー用のStep Functionsタスクトークン)
+  syncMode?: CommandSyncMode  // 'SYNC' when the command was applied via synchronous publish (同期publishで適用されたコマンドは'SYNC')
 }
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/key-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/key-patterns.md
@@ -91,7 +91,8 @@ ID = PK#SK (without version)
 | `VER_SEPARATOR` | `@` | ソートキーとバージョン番号を区切る |
 | `VERSION_FIRST` | `0` | 新しいエンティティの初期バージョン |
 | `VERSION_LATEST` | `-1` | 最新バージョンのクエリを示す |
-| `TENANT_COMMON` | `common` | 共有/クロステナントデータ用のテナントコード |
+| `TENANT_COMMON` | `common` | 共有・テナント横断データ用のテナントコード（非推奨 — DEFAULT_COMMON_TENANT_CODES を使用） |
+| `DEFAULT_COMMON_TENANT_CODES` | `['common']` | 共通テナントコードのリスト（環境変数 COMMON_TENANT_CODES で設定可能） |
 | `DEFAULT_TENANT_CODE` | `single` | シングルテナントモードのデフォルトテナント |
 
 :::tip 一貫したテナントコード形式

--- a/i18n/ja/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
@@ -240,10 +240,8 @@ export class UserService {
   async getUserTenants(userCode: string): Promise<UserTenantAssociation[]> {
     const pk = `USER_TENANT${KEY_SEPARATOR}${COMMON_TENANT}`;
 
-    // SKプレフィックスで全テナント関連を検索
-    const result = await this.dataService.listItemsByPk(pk, {
-      skPrefix: '', // Get all, then filter
-    });
+    // List all items under the PK, then filter by user code (PK配下の全アイテムを取得し、ユーザーコードで絞り込み)
+    const result = await this.dataService.listItemsByPk(pk);
 
     return result.items.filter(item =>
       item.sk.endsWith(`${KEY_SEPARATOR}${userCode}`),

--- a/i18n/ja/docusaurus-plugin-content-docs/current/service-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/service-patterns.md
@@ -360,7 +360,8 @@ export class ProductService {
       invokeContext: opts.invokeContext,
     });
 
-    return new ProductDataEntity(item);
+    // publishAsync returns null when the command is not dirty (変更がない場合 publishAsync は null を返す)
+    return item ? new ProductDataEntity(item) : null;
   }
 
   /**

--- a/i18n/ja/translation/helpers.json
+++ b/i18n/ja/translation/helpers.json
@@ -14,7 +14,6 @@
   "Generates a unique ID by combining partition key and sort key (without version).": "パーティションキーとソートキー（バージョンなし）を組み合わせて一意のIDを生成します。",
   "Result: 'TENANT#mbc#CAT#001'": "結果: 'TENANT#mbc#CAT#001'",
   "The inverse of `generateId`: extracts the base sort key from a composite ID. Returns `undefined` if the ID does not start with the given partition key.": "`generateId` の逆操作: 複合IDからベースとなるソートキーを抽出します。IDが指定したパーティションキーで始まらない場合は `undefined` を返します。",
-  "Result: 'CAT#001'": "結果: 'CAT#001'",
   "Splits a composite ID back into its partition key and base sort key, assuming the partition key has two segments (type and tenant code). Returns `undefined` if the ID has fewer than three segments.": "複合IDをパーティションキーとベースソートキーに分割します。パーティションキーが2セグメント（タイプとテナントコード）であることを前提とします。IDのセグメントが3つ未満の場合は `undefined` を返します。",
   "result.pk is 'TENANT#mbc' and result.skBase is 'CAT#001'": "result.pk は 'TENANT#mbc'、result.skBase は 'CAT#001' になります",
   "Extracts the tenant code from a partition key.": "パーティションキーからテナントコードを抽出します。",
@@ -119,5 +118,7 @@
   "Command Service": "コマンドサービス",
   "Using key helpers": "キーヘルパーの使用",
   "Interfaces": "インターフェース",
-  "UserContext and IInvoke interfaces": "UserContextとIInvokeインターフェース"
+  "UserContext and IInvoke interfaces": "UserContextとIInvokeインターフェース",
+  "Direct roles for the active tenant (excludes group-derived roles)": "Direct roles for the active tenant (アクティブテナントの直接ロール、グループ由来ロールを除く)",
+  "Group IDs from custom:groups for the active tenant": "Group IDs from custom:groups for the active tenant (custom:groups由来のグループID)"
 }

--- a/i18n/ja/translation/interfaces.json
+++ b/i18n/ja/translation/interfaces.json
@@ -115,5 +115,9 @@
   "Entity Patterns": "エンティティパターン",
   "Designing entities": "エンティティの設計",
   "Error Catalog": "エラーカタログ",
-  "Error handling": "エラー処理"
+  "Error handling": "エラー処理",
+  "Custom claim for tenant group memberships JSON array": "Custom claim for tenant group memberships JSON array (テナントグループ所属のJSON配列カスタムクレーム)",
+  "Direct roles for the active tenant (excludes group-derived roles)": "Direct roles for the active tenant (アクティブテナントの直接ロール、グループ由来ロールを除く)",
+  "Group IDs from custom:groups for the active tenant": "Group IDs from custom:groups for the active tenant (custom:groups由来のグループID)",
+  "'SYNC' when the command was applied via synchronous publish": "'SYNC' when the command was applied via synchronous publish (同期publishで適用されたコマンドは'SYNC')"
 }

--- a/i18n/ja/translation/key-patterns.json
+++ b/i18n/ja/translation/key-patterns.json
@@ -71,7 +71,7 @@
   "Separates sort key from version number": "ソートキーとバージョン番号を区切る",
   "Initial version for new entities": "新しいエンティティの初期バージョン",
   "Indicates query for latest version": "最新バージョンのクエリを示す",
-  "Tenant code for shared/cross-tenant data": "共有/クロステナントデータ用のテナントコード",
+  "Tenant code for shared/cross-tenant data (deprecated — use DEFAULT_COMMON_TENANT_CODES)": "共有・テナント横断データ用のテナントコード（非推奨 — DEFAULT_COMMON_TENANT_CODES を使用）",
   "Default tenant for single-tenant mode": "シングルテナントモードのデフォルトテナント",
   "Consistent Tenant Code Format": "一貫したテナントコード形式",
   "The `@mbc-cqrs-serverless/master` and `@mbc-cqrs-serverless/tenant` packages use `SettingTypeEnum.TENANT_COMMON = 'common'` (lowercase), which is consistent with the tenant code normalization in `getUserContext()`. This ensures that data saved by `createCommonTenantSetting()` or `createCommonTenant()` methods can be correctly queried.": "`@mbc-cqrs-serverless/master`と`@mbc-cqrs-serverless/tenant`パッケージは`SettingTypeEnum.TENANT_COMMON = 'common'`（小文字）を使用しており、`getUserContext()`のテナントコード正規化と一貫しています。これにより、`createCommonTenantSetting()`や`createCommonTenant()`メソッドで保存されたデータを正しくクエリできます。",
@@ -210,5 +210,6 @@
   "Use when creating new entities": "新しいエンティティ作成時に使用",
   "Returned when SK has no version": "SKにバージョンがない場合に返される",
   "Use for cross-tenant shared data": "クロステナント共有データに使用",
-  "Default for single-tenant mode": "シングルテナントモードのデフォルト"
+  "Default for single-tenant mode": "シングルテナントモードのデフォルト",
+  "Common tenant codes list, configurable via COMMON_TENANT_CODES env var": "共通テナントコードのリスト（環境変数 COMMON_TENANT_CODES で設定可能）"
 }

--- a/i18n/ja/translation/multi-tenant-patterns.json
+++ b/i18n/ja/translation/multi-tenant-patterns.json
@@ -49,7 +49,7 @@
   "Pattern 3: User-Tenant Association": "パターン3: ユーザー・テナント関連付け",
   "Handle users belonging to multiple tenants:": "複数のテナントに所属するユーザーを処理します：",
   "Get all tenants a user belongs to": "Get all tenants a user belongs to (ユーザーが所属する全テナントを取得)",
-  "Query with SK prefix to find all tenant associations": "SKプレフィックスで全テナント関連を検索",
+  "List all items under the PK, then filter by user code": "List all items under the PK, then filter by user code (PK配下の全アイテムを取得し、ユーザーコードで絞り込み)",
   "Add user to tenant": "Add user to tenant (ユーザーをテナントに追加)",
   "Switch user's active tenant": "Switch user's active tenant (ユーザーのアクティブテナントを切り替え)",
   "Verify user belongs to tenant": "ユーザーがテナントに属することを確認",

--- a/i18n/ja/translation/service-patterns.json
+++ b/i18n/ja/translation/service-patterns.json
@@ -110,5 +110,6 @@
   "Data Service": "データサービス",
   "DataService query methods": "DataServiceクエリメソッド",
   "Database Selection Guide": "データベース選択ガイド",
-  "DynamoDB vs RDS": "DynamoDB対RDSの比較"
+  "DynamoDB vs RDS": "DynamoDB対RDSの比較",
+  "publishAsync returns null when the command is not dirty (no-op)": "publishAsync returns null when the command is not dirty (変更がない場合 publishAsync は null を返す)"
 }


### PR DESCRIPTION
## 概要

パターン系・リファレンス系ドキュメント（multi-tenant-patterns / helpers / interfaces / key-patterns / service-patterns / event-handling-patterns / entity-patterns）を origin/main 実装と突き合わせた結果の修正です。

## 修正内容

1. **multi-tenant-patterns.md** — `listItemsByPk` に存在しない `skPrefix` オプションを渡すコード例を修正（実装のオプションは `sk.skExpression` 形式のみ。この例は全件取得→メモリ内フィルタの意図のため第2引数を削除）
2. **helpers.md / interfaces.md** — v1.3.1 のグループベースロールで `UserContext` に追加された `tenantRoles` / `tenantGroupIds` が両ページのクラス定義に未記載。`JwtClaims` の `'custom:groups'` クレーム、`CommandModel` の `syncMode` マーカーも追記
3. **key-patterns.md** — `TENANT_COMMON` は実装で `@deprecated`（`DEFAULT_COMMON_TENANT_CODES` 推奨）のため定数表に非推奨を明記し、`DEFAULT_COMMON_TENANT_CODES` の行を追加
4. **service-patterns.md** — v1.2.0 以降 `publishAsync` は `CommandModel | null` を返すのに null チェックなしでエンティティ化していた例を null 安全に修正

## 調査で確認した正常項目（変更なし）

- helpers.md の全31ヘルパー関数、interfaces.md の主要インターフェース群は実装と一致
- event-handling-patterns.md は全12項目（@EventHandler / DefaultEventFactory / EmailService 等）一致
- key/entity/service-patterns の74項目（定数・エンティティ・シグネチャ・import パス）一致

## 検証

- 実装は `git show origin/main:...` で直接確認（フレームワークのソースは未変更）
- en/ja 翻訳 JSON 更新、再生成後の未解決 placeholder 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)