### PR TITLE
docs: fix master-web component props and data-migration API usage

### DIFF
--- a/docs/data-migration-patterns.md
+++ b/docs/data-migration-patterns.md
@@ -676,7 +676,7 @@ export class SchemaTransformationStrategy
    * {{Map old schema to new schema}}
    */
   async map(
-    status: ComparisonStatus,
+    status: Exclude<ComparisonStatus, ComparisonStatus.EQUAL>,
     dto: NewProductAttributes,
     tenantCode: string,
     existingData?: DataModel,
@@ -938,7 +938,7 @@ export class MigrationProcessStrategy
    * {{Map migration data to command payload}}
    */
   async map(
-    status: ComparisonStatus,
+    status: Exclude<ComparisonStatus, ComparisonStatus.EQUAL>,
     dto: MigrationDto,
     tenantCode: string,
     existingData?: DataModel,
@@ -1099,6 +1099,8 @@ export class RollbackService {
 
 ```typescript
 // migration/safe-migration.service.ts
+import { parseTwoSegmentPkSkFromId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class SafeMigrationService {
   /**
@@ -1160,7 +1162,9 @@ export class SafeMigrationService {
   ): Promise<void> {
     // {{Restore original records}}
     for (const id of originalIds) {
-      const item = await this.dataService.getItemById(id);
+      const parsed = parseTwoSegmentPkSkFromId(id);
+      if (!parsed) continue;
+      const item = await this.dataService.getItem({ pk: parsed.pk, sk: parsed.skBase });
       if (item?.isDeleted) {
         await this.commandService.publishPartialUpdateSync({
           pk: item.pk,
@@ -1179,7 +1183,9 @@ export class SafeMigrationService {
 
     // {{Hard delete migrated records}}
     for (const id of migratedIds) {
-      const item = await this.dataService.getItemById(id);
+      const parsed = parseTwoSegmentPkSkFromId(id);
+      if (!parsed) continue;
+      const item = await this.dataService.getItem({ pk: parsed.pk, sk: parsed.skBase });
       if (item) {
         await this.commandService.publishPartialUpdateSync({
           pk: item.pk,

--- a/docs/master-web.md
+++ b/docs/master-web.md
@@ -217,8 +217,9 @@ export default function MasterSettingsPage() {
 ```tsx
 import { EditMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function EditMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <EditMasterSettings id={params.id} />;
+// {{The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]}}
+export default function EditMasterSettingsPage() {
+  return <EditMasterSettings />;
 }
 ```
 
@@ -229,8 +230,9 @@ export default function EditMasterSettingsPage({ params }: { params: { id: strin
 ```tsx
 import { CopyMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function CopyMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <CopyMasterSettings id={params.id} />;
+// {{The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]}}
+export default function CopyMasterSettingsPage() {
+  return <CopyMasterSettings />;
 }
 ```
 
@@ -241,8 +243,9 @@ export default function CopyMasterSettingsPage({ params }: { params: { id: strin
 ```tsx
 import { NewCopyMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function NewCopyMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <NewCopyMasterSettings id={params.id} />;
+// {{The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]}}
+export default function NewCopyMasterSettingsPage() {
+  return <NewCopyMasterSettings />;
 }
 ```
 
@@ -253,8 +256,9 @@ export default function NewCopyMasterSettingsPage({ params }: { params: { id: st
 ```tsx
 import { DetailCopy } from "@mbc-cqrs-serverless/master-web";
 
-export default function DetailCopyPage({ params }: { params: { id: string } }) {
-  return <DetailCopy id={params.id} />;
+// {{The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]}}
+export default function DetailCopyPage() {
+  return <DetailCopy />;
 }
 ```
 
@@ -279,8 +283,9 @@ export default function MasterDataPage() {
 ```tsx
 import { EditMasterData } from "@mbc-cqrs-serverless/master-web";
 
-export default function EditMasterDataPage({ params }: { params: { id: string } }) {
-  return <EditMasterData id={params.id} />;
+// {{The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]}}
+export default function EditMasterDataPage() {
+  return <EditMasterData />;
 }
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/data-migration-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/data-migration-patterns.md
@@ -676,7 +676,7 @@ export class SchemaTransformationStrategy
    * Map old schema to new schema
    */
   async map(
-    status: ComparisonStatus,
+    status: Exclude<ComparisonStatus, ComparisonStatus.EQUAL>,
     dto: NewProductAttributes,
     tenantCode: string,
     existingData?: DataModel,
@@ -938,7 +938,7 @@ export class MigrationProcessStrategy
    * Map migration data to command payload
    */
   async map(
-    status: ComparisonStatus,
+    status: Exclude<ComparisonStatus, ComparisonStatus.EQUAL>,
     dto: MigrationDto,
     tenantCode: string,
     existingData?: DataModel,
@@ -1099,6 +1099,8 @@ Use soft delete to enable easy recovery.
 
 ```typescript
 // migration/safe-migration.service.ts
+import { parseTwoSegmentPkSkFromId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class SafeMigrationService {
   /**
@@ -1160,7 +1162,9 @@ export class SafeMigrationService {
   ): Promise<void> {
     // Restore original records
     for (const id of originalIds) {
-      const item = await this.dataService.getItemById(id);
+      const parsed = parseTwoSegmentPkSkFromId(id);
+      if (!parsed) continue;
+      const item = await this.dataService.getItem({ pk: parsed.pk, sk: parsed.skBase });
       if (item?.isDeleted) {
         await this.commandService.publishPartialUpdateSync({
           pk: item.pk,
@@ -1179,7 +1183,9 @@ export class SafeMigrationService {
 
     // Hard delete migrated records
     for (const id of migratedIds) {
-      const item = await this.dataService.getItemById(id);
+      const parsed = parseTwoSegmentPkSkFromId(id);
+      if (!parsed) continue;
+      const item = await this.dataService.getItem({ pk: parsed.pk, sk: parsed.skBase });
       if (item) {
         await this.commandService.publishPartialUpdateSync({
           pk: item.pk,

--- a/i18n/en/docusaurus-plugin-content-docs/current/master-web.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/master-web.md
@@ -217,8 +217,9 @@ Form component for creating and editing master settings.
 ```tsx
 import { EditMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function EditMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <EditMasterSettings id={params.id} />;
+// The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]
+export default function EditMasterSettingsPage() {
+  return <EditMasterSettings />;
 }
 ```
 
@@ -229,8 +230,9 @@ Component for copying master settings to create new settings based on existing o
 ```tsx
 import { CopyMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function CopyMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <CopyMasterSettings id={params.id} />;
+// The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]
+export default function CopyMasterSettingsPage() {
+  return <CopyMasterSettings />;
 }
 ```
 
@@ -241,8 +243,9 @@ Component for creating a new copy of master settings with a new identifier.
 ```tsx
 import { NewCopyMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function NewCopyMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <NewCopyMasterSettings id={params.id} />;
+// The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]
+export default function NewCopyMasterSettingsPage() {
+  return <NewCopyMasterSettings />;
 }
 ```
 
@@ -253,8 +256,9 @@ Component for viewing detailed copy information of master settings.
 ```tsx
 import { DetailCopy } from "@mbc-cqrs-serverless/master-web";
 
-export default function DetailCopyPage({ params }: { params: { id: string } }) {
-  return <DetailCopy id={params.id} />;
+// The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]
+export default function DetailCopyPage() {
+  return <DetailCopy />;
 }
 ```
 
@@ -279,8 +283,9 @@ The component always displays `code` and `name` as fixed fields. Any additional 
 ```tsx
 import { EditMasterData } from "@mbc-cqrs-serverless/master-web";
 
-export default function EditMasterDataPage({ params }: { params: { id: string } }) {
-  return <EditMasterData id={params.id} />;
+// The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]
+export default function EditMasterDataPage() {
+  return <EditMasterData />;
 }
 ```
 

--- a/i18n/en/translation/master-web.json
+++ b/i18n/en/translation/master-web.json
@@ -422,5 +422,6 @@
   "Frontend Project Structure": "Frontend Project Structure",
   "Project structure": "Project structure",
   "API Integration Patterns": "API Integration Patterns",
-  "API patterns": "API patterns"
+  "API patterns": "API patterns",
+  "The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]": "The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]"
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/data-migration-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/data-migration-patterns.md
@@ -676,7 +676,7 @@ export class SchemaTransformationStrategy
    * Map old schema to new schema (旧スキーマを新スキーマにマッピング)
    */
   async map(
-    status: ComparisonStatus,
+    status: Exclude<ComparisonStatus, ComparisonStatus.EQUAL>,
     dto: NewProductAttributes,
     tenantCode: string,
     existingData?: DataModel,
@@ -938,7 +938,7 @@ export class MigrationProcessStrategy
    * Map migration data to command payload (移行データをコマンドペイロードにマッピング)
    */
   async map(
-    status: ComparisonStatus,
+    status: Exclude<ComparisonStatus, ComparisonStatus.EQUAL>,
     dto: MigrationDto,
     tenantCode: string,
     existingData?: DataModel,
@@ -1099,6 +1099,8 @@ export class RollbackService {
 
 ```typescript
 // migration/safe-migration.service.ts
+import { parseTwoSegmentPkSkFromId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class SafeMigrationService {
   /**
@@ -1160,7 +1162,9 @@ export class SafeMigrationService {
   ): Promise<void> {
     // Restore original records (元のレコードを復元)
     for (const id of originalIds) {
-      const item = await this.dataService.getItemById(id);
+      const parsed = parseTwoSegmentPkSkFromId(id);
+      if (!parsed) continue;
+      const item = await this.dataService.getItem({ pk: parsed.pk, sk: parsed.skBase });
       if (item?.isDeleted) {
         await this.commandService.publishPartialUpdateSync({
           pk: item.pk,
@@ -1179,7 +1183,9 @@ export class SafeMigrationService {
 
     // Hard delete migrated records (移行されたレコードをハード削除)
     for (const id of migratedIds) {
-      const item = await this.dataService.getItemById(id);
+      const parsed = parseTwoSegmentPkSkFromId(id);
+      if (!parsed) continue;
+      const item = await this.dataService.getItem({ pk: parsed.pk, sk: parsed.skBase });
       if (item) {
         await this.commandService.publishPartialUpdateSync({
           pk: item.pk,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/master-web.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/master-web.md
@@ -217,8 +217,9 @@ export default function MasterSettingsPage() {
 ```tsx
 import { EditMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function EditMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <EditMasterSettings id={params.id} />;
+// The component takes no props (このコンポーネントは props を受け取らず、useParams() で URL から pk と sk を読み取るため、[pk]/[sk] のようなルート配下に配置してください)
+export default function EditMasterSettingsPage() {
+  return <EditMasterSettings />;
 }
 ```
 
@@ -229,8 +230,9 @@ export default function EditMasterSettingsPage({ params }: { params: { id: strin
 ```tsx
 import { CopyMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function CopyMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <CopyMasterSettings id={params.id} />;
+// The component takes no props (このコンポーネントは props を受け取らず、useParams() で URL から pk と sk を読み取るため、[pk]/[sk] のようなルート配下に配置してください)
+export default function CopyMasterSettingsPage() {
+  return <CopyMasterSettings />;
 }
 ```
 
@@ -241,8 +243,9 @@ export default function CopyMasterSettingsPage({ params }: { params: { id: strin
 ```tsx
 import { NewCopyMasterSettings } from "@mbc-cqrs-serverless/master-web";
 
-export default function NewCopyMasterSettingsPage({ params }: { params: { id: string } }) {
-  return <NewCopyMasterSettings id={params.id} />;
+// The component takes no props (このコンポーネントは props を受け取らず、useParams() で URL から pk と sk を読み取るため、[pk]/[sk] のようなルート配下に配置してください)
+export default function NewCopyMasterSettingsPage() {
+  return <NewCopyMasterSettings />;
 }
 ```
 
@@ -253,8 +256,9 @@ export default function NewCopyMasterSettingsPage({ params }: { params: { id: st
 ```tsx
 import { DetailCopy } from "@mbc-cqrs-serverless/master-web";
 
-export default function DetailCopyPage({ params }: { params: { id: string } }) {
-  return <DetailCopy id={params.id} />;
+// The component takes no props (このコンポーネントは props を受け取らず、useParams() で URL から pk と sk を読み取るため、[pk]/[sk] のようなルート配下に配置してください)
+export default function DetailCopyPage() {
+  return <DetailCopy />;
 }
 ```
 
@@ -279,8 +283,9 @@ export default function MasterDataPage() {
 ```tsx
 import { EditMasterData } from "@mbc-cqrs-serverless/master-web";
 
-export default function EditMasterDataPage({ params }: { params: { id: string } }) {
-  return <EditMasterData id={params.id} />;
+// The component takes no props (このコンポーネントは props を受け取らず、useParams() で URL から pk と sk を読み取るため、[pk]/[sk] のようなルート配下に配置してください)
+export default function EditMasterDataPage() {
+  return <EditMasterData />;
 }
 ```
 

--- a/i18n/ja/translation/master-web.json
+++ b/i18n/ja/translation/master-web.json
@@ -422,5 +422,6 @@
   "Frontend Project Structure": "フロントエンドプロジェクト構成",
   "Project structure": "プロジェクト構成",
   "API Integration Patterns": "API統合パターン",
-  "API patterns": "APIパターン"
+  "API patterns": "APIパターン",
+  "The component takes no props — it reads pk and sk from the URL via useParams(), so place it under a route like [pk]/[sk]": "The component takes no props (このコンポーネントは props を受け取らず、useParams() で URL から pk と sk を読み取るため、[pk]/[sk] のようなルート配下に配置してください)"
 }


### PR DESCRIPTION
## 概要

フロントエンド系（master-web / survey-web / パターン集4本）と import-export / data-migration / data-sync-handler / api-integration-guide を実装と突き合わせた結果の修正です。

## 修正内容

### master-web.md — コンポーネント使用例5件の props 誤り（高重大度）

`EditMasterSettings` / `CopyMasterSettings` / `NewCopyMasterSettings` / `DetailCopy` / `EditMasterData` を「`id` prop を渡す」と説明していましたが、web リポジトリの実装（v0.0.42）ではいずれも **props を受け取らず `useParams()` で URL から pk/sk を読む**設計です。5例すべてを修正し、`[pk]/[sk]` ルート配下に置く旨を注記。

### data-migration-patterns.md

1. `IProcessStrategy.map` の status 型2箇所を `Exclude<ComparisonStatus, ComparisonStatus.EQUAL>` に修正（PR #81 の import.md と同種）
2. 存在しない `dataService.getItemById(id)` 呼び出し2箇所を、公開ヘルパー `parseTwoSegmentPkSkFromId` ＋ `getItem({pk, sk})` に修正（import 行も追加）

## 調査で確認した正常項目（変更なし）

- survey-web.md は useParams ベースの記載で実装と一致
- パッケージ名・メインコンポーネント・AppProviders・各 hooks（useHttpClient 等）一致
- import-export-patterns / data-sync-handler-examples / api-integration-guide はコード例100件以上が実装と一致

## 検証

- web 実装は作業ツリーを直接確認、フレームワークは `git show origin/main:...` で確認（どちらもソース未変更）
- en/ja 翻訳 JSON 更新、再生成後の未解決 placeholder 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)