### PR TITLE
docs: align MCP setup example and stale error message in AI docs

### DIFF
--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -73,7 +73,10 @@ claude mcp add context7 -- npx -y @upstash/context7-mcp@latest
   "mcpServers": {
     "mbc-cqrs-serverless": {
       "command": "npx",
-      "args": ["@mbc-cqrs-serverless/mcp-server"]
+      "args": ["@mbc-cqrs-serverless/mcp-server"],
+      "env": {
+        "MBC_PROJECT_PATH": "/path/to/your/project"
+      }
     }
   }
 }

--- a/docs/ai-prompts.md
+++ b/docs/ai-prompts.md
@@ -157,7 +157,7 @@ Write integration tests for [FEATURE]:
 ### {{Diagnose Version Conflict}}
 
 ```
-I'm getting a "version not match" error when updating [ENTITY].
+I'm getting an "Invalid input: item not found or version mismatch" error when updating [ENTITY].
 Please help me:
 1. Understand why this error occurs in CQRS/Event Sourcing
 2. Check if I'm using the correct version in my update

--- a/i18n/en/docusaurus-plugin-content-docs/current/ai-integration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ai-integration.md
@@ -73,7 +73,10 @@ Add to Claude Code or other MCP-compatible tools:
   "mcpServers": {
     "mbc-cqrs-serverless": {
       "command": "npx",
-      "args": ["@mbc-cqrs-serverless/mcp-server"]
+      "args": ["@mbc-cqrs-serverless/mcp-server"],
+      "env": {
+        "MBC_PROJECT_PATH": "/path/to/your/project"
+      }
     }
   }
 }

--- a/i18n/en/docusaurus-plugin-content-docs/current/ai-prompts.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ai-prompts.md
@@ -157,7 +157,7 @@ Write integration tests for [FEATURE]:
 ### Diagnose Version Conflict
 
 ```
-I'm getting a "version not match" error when updating [ENTITY].
+I'm getting an "Invalid input: item not found or version mismatch" error when updating [ENTITY].
 Please help me:
 1. Understand why this error occurs in CQRS/Event Sourcing
 2. Check if I'm using the correct version in my update

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai-integration.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai-integration.md
@@ -73,7 +73,10 @@ Claude Codeまたは他のMCP互換ツールに追加：
   "mcpServers": {
     "mbc-cqrs-serverless": {
       "command": "npx",
-      "args": ["@mbc-cqrs-serverless/mcp-server"]
+      "args": ["@mbc-cqrs-serverless/mcp-server"],
+      "env": {
+        "MBC_PROJECT_PATH": "/path/to/your/project"
+      }
     }
   }
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai-prompts.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai-prompts.md
@@ -157,7 +157,7 @@ Write integration tests for [FEATURE]:
 ### バージョン競合の診断
 
 ```
-I'm getting a "version not match" error when updating [ENTITY].
+I'm getting an "Invalid input: item not found or version mismatch" error when updating [ENTITY].
 Please help me:
 1. Understand why this error occurs in CQRS/Event Sourcing
 2. Check if I'm using the correct version in my update


### PR DESCRIPTION
## 概要

残り6本のドキュメント（glossary / ai-prompts / ai-integration / survey-template / version-conflict-guide / absolute_imports）の検証結果です。**これで全79ドキュメントの実装突き合わせが一巡完了**しました。

## 修正内容

1. **ai-integration.md** — MCP サーバー設定例に `env: { MBC_PROJECT_PATH }` が欠落（mcp-server README と mcp-server.md には記載あり）。これがないと MCP サーバーがプロジェクトを特定できないため整合
2. **ai-prompts.md** — バージョン競合デバッグ用プロンプトが v1.0.25 以前の旧エラーメッセージ（"version not match"）を引用していたため現行文言に更新

## 検証で正確と確認（変更なし）

- glossary.md（用語定義）、survey-template.md（API・サービスメソッド）、version-conflict-guide.md（現行エラーメッセージ引用済み）、absolute_imports（汎用 tsconfig ガイダンスとして妥当）
- ai-integration.md の MCP ツール名6種はすべて実装と一致

## 検証

- 実装は `git show origin/main:...` で直接確認（フレームワークのソースは未変更）
- コードブロック内のみの変更のため翻訳 JSON 変更不要、en/ja 再生成済み・未解決 placeholder 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)