### PR TITLE
fix: add import_tmp prerequisite note and null check in backend-development example

### DIFF
--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -285,6 +285,8 @@ export class ProductService {
       invokeContext: opts.invokeContext,
     });
 
+    // {{publishAsync returns null when command is a no-op (no changes detected)}}
+    if (!item) return null;
     return new ProductDataEntity(item);
   }
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -38,6 +38,10 @@ graph TB
 npm install @mbc-cqrs-serverless/import
 ```
 
+:::info {{Prerequisite: `import_tmp` DynamoDB Table}}
+{{The import module requires an `import_tmp` DynamoDB table with a DynamoDB Stream. Run `npm run migrate` after scaffolding to create this table automatically. If `npm run offline:sls` fails with a `LOCAL_DDB_IMPORT_TMP_STREAM` error, see [Serverless Offline fails with missing import_tmp stream](/docs/common-issues#missing-import-tmp-table) for the fix.}}
+:::
+
 ## {{Module Registration}}
 
 ```ts

--- a/i18n/en/docusaurus-plugin-content-docs/current/backend-development.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/backend-development.md
@@ -285,6 +285,8 @@ export class ProductService {
       invokeContext: opts.invokeContext,
     });
 
+    // publishAsync returns null when command is a no-op (no changes detected)
+    if (!item) return null;
     return new ProductDataEntity(item);
   }
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/import.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/import.md
@@ -38,6 +38,10 @@ Since [v1.2.5](/docs/changelog#v125), ZIP import jobs are processed directly wit
 npm install @mbc-cqrs-serverless/import
 ```
 
+:::info Prerequisite: `import_tmp` DynamoDB Table
+The import module requires an `import_tmp` DynamoDB table with a DynamoDB Stream. Run `npm run migrate` after scaffolding to create this table automatically. If `npm run offline:sls` fails with a `LOCAL_DDB_IMPORT_TMP_STREAM` error, see [Serverless Offline fails with missing import_tmp stream](/docs/common-issues#missing-import-tmp-table) for the fix.
+:::
+
 ## Module Registration
 
 ```ts

--- a/i18n/en/translation/backend-development.json
+++ b/i18n/en/translation/backend-development.json
@@ -61,5 +61,6 @@
   "Multi-Tenant Patterns": "Multi-Tenant Patterns",
   "Multi-tenant implementation": "Multi-tenant implementation",
   "Import/Export Patterns": "Import/Export Patterns",
-  "Batch data processing": "Batch data processing"
+  "Batch data processing": "Batch data processing",
+  "publishAsync returns null when command is a no-op (no changes detected)": "publishAsync returns null when command is a no-op (no changes detected)"
 }

--- a/i18n/en/translation/import.json
+++ b/i18n/en/translation/import.json
@@ -133,5 +133,7 @@
   "Data Migration Patterns": "Data Migration Patterns",
   "Migration strategies": "Migration strategies",
   "Tasks": "Tasks",
-  "Step Functions task management": "Step Functions task management"
+  "Step Functions task management": "Step Functions task management",
+  "Prerequisite: `import_tmp` DynamoDB Table": "Prerequisite: `import_tmp` DynamoDB Table",
+  "The import module requires an `import_tmp` DynamoDB table with a DynamoDB Stream. Run `npm run migrate` after scaffolding to create this table automatically. If `npm run offline:sls` fails with a `LOCAL_DDB_IMPORT_TMP_STREAM` error, see [Serverless Offline fails with missing import_tmp stream](/docs/common-issues#missing-import-tmp-table) for the fix.": "The import module requires an `import_tmp` DynamoDB table with a DynamoDB Stream. Run `npm run migrate` after scaffolding to create this table automatically. If `npm run offline:sls` fails with a `LOCAL_DDB_IMPORT_TMP_STREAM` error, see [Serverless Offline fails with missing import_tmp stream](/docs/common-issues#missing-import-tmp-table) for the fix."
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/backend-development.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/backend-development.md
@@ -285,6 +285,8 @@ export class ProductService {
       invokeContext: opts.invokeContext,
     });
 
+    // publishAsync は変更がない場合（no-op）null を返す
+    if (!item) return null;
     return new ProductDataEntity(item);
   }
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/import.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/import.md
@@ -38,6 +38,10 @@ graph TB
 npm install @mbc-cqrs-serverless/import
 ```
 
+:::info 前提条件: `import_tmp` DynamoDBテーブル
+importモジュールはDynamoDB Streamを持つ`import_tmp` DynamoDBテーブルが必要です。スキャフォールド後に`npm run migrate`を実行するとこのテーブルが自動的に作成されます。`npm run offline:sls`が`LOCAL_DDB_IMPORT_TMP_STREAM`エラーで失敗する場合は、[Serverless Offlineでimport_tmpストリームが見つからない](/docs/common-issues#missing-import-tmp-table)を参照してください。
+:::
+
 ## モジュール登録
 
 ```ts

--- a/i18n/ja/translation/backend-development.json
+++ b/i18n/ja/translation/backend-development.json
@@ -61,5 +61,6 @@
   "Multi-Tenant Patterns": "マルチテナントパターン",
   "Multi-tenant implementation": "マルチテナント実装",
   "Import/Export Patterns": "インポート/エクスポートパターン",
-  "Batch data processing": "バッチデータ処理"
+  "Batch data processing": "バッチデータ処理",
+  "publishAsync returns null when command is a no-op (no changes detected)": "publishAsync は変更がない場合（no-op）null を返す"
 }

--- a/i18n/ja/translation/import.json
+++ b/i18n/ja/translation/import.json
@@ -133,5 +133,7 @@
   "Data Migration Patterns": "データ移行パターン",
   "Migration strategies": "移行戦略",
   "Tasks": "タスク",
-  "Step Functions task management": "Step Functionsタスク管理"
+  "Step Functions task management": "Step Functionsタスク管理",
+  "Prerequisite: `import_tmp` DynamoDB Table": "前提条件: `import_tmp` DynamoDBテーブル",
+  "The import module requires an `import_tmp` DynamoDB table with a DynamoDB Stream. Run `npm run migrate` after scaffolding to create this table automatically. If `npm run offline:sls` fails with a `LOCAL_DDB_IMPORT_TMP_STREAM` error, see [Serverless Offline fails with missing import_tmp stream](/docs/common-issues#missing-import-tmp-table) for the fix.": "importモジュールはDynamoDB Streamを持つ`import_tmp` DynamoDBテーブルが必要です。スキャフォールド後に`npm run migrate`を実行するとこのテーブルが自動的に作成されます。`npm run offline:sls`が`LOCAL_DDB_IMPORT_TMP_STREAM`エラーで失敗する場合は、[Serverless Offlineでimport_tmpストリームが見つからない](/docs/common-issues#missing-import-tmp-table)を参照してください。"
 }


### PR DESCRIPTION
## Summary

- **import.md**: Added an `:::info` admonition in the Installation section that explains the `import_tmp` DynamoDB table must exist before using the ImportModule. Links directly to [common-issues#missing-import-tmp-table](/docs/common-issues#missing-import-tmp-table) for the fix. Developers following the import.md guide would otherwise hit a confusing runtime error.
- **backend-development.md**: Added null guard after the `publishAsync` call in the create service example (`if (!item) return null`). In v1.2.0+, `publishAsync` returns `CommandModel | null` — without the guard, the `new ProductDataEntity(item)` call would fail at runtime when the command produces no change.

## Test plan

- [x] `npm run translate:replace-placeholders` — ran successfully
- [x] `npm run build` — compiled successfully (80 EN + 80 JA docs)
- [x] EN and JA translation files updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)