### PR TITLE
docs: fix React hook patterns in form and state management examples

### DIFF
--- a/docs/form-handling-patterns.md
+++ b/docs/form-handling-patterns.md
@@ -248,10 +248,9 @@ export function ProductForm({
 
         <Button
           type="submit"
-          loading={form.formState.isSubmitting || isLoading}
           disabled={form.formState.isSubmitting || isLoading}
         >
-          Save
+          {form.formState.isSubmitting || isLoading ? '{{Saving...}}' : '{{Save}}'}
         </Button>
       </form>
     </Form>

--- a/docs/state-management-patterns.md
+++ b/docs/state-management-patterns.md
@@ -328,21 +328,20 @@ function ProductList() {
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(false)
 
-  const fetchProducts = async () => {
-    setLoading(true)
-    try {
-      const response = await httpClient.get('/products')
-      setProducts(response.data)
-    } catch (error) {
-      console.error('Failed to fetch products:', error)
-    } finally {
-      setLoading(false)
-    }
-  }
-
   useEffect(() => {
+    const fetchProducts = async () => {
+      setLoading(true)
+      try {
+        const response = await httpClient.get('/products')
+        setProducts(response.data)
+      } catch (error) {
+        console.error('Failed to fetch products:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
     fetchProducts()
-  }, [])
+  }, [httpClient])
 
   return (
     <div>

--- a/i18n/en/translation/form-handling-patterns.json
+++ b/i18n/en/translation/form-handling-patterns.json
@@ -112,6 +112,8 @@
   "Scenario: Server returns field-level validation errors.": "Scenario: Server returns field-level validation errors.",
   "Solution: Use setError to display server errors on specific fields.": "Solution: Use setError to display server errors on specific fields.",
   "Set field-level errors from server": "Set field-level errors from server",
+  "Saving...": "Saving...",
+  "Save": "Save",
   "Related Documentation": "Related Documentation",
   "API Integration Patterns": "API Integration Patterns",
   "API calls from forms": "API calls from forms",

--- a/i18n/ja/translation/form-handling-patterns.json
+++ b/i18n/ja/translation/form-handling-patterns.json
@@ -112,6 +112,8 @@
   "Scenario: Server returns field-level validation errors.": "シナリオ: サーバーがフィールドレベルのバリデーションエラーを返す。",
   "Solution: Use setError to display server errors on specific fields.": "解決策: setErrorを使用してサーバーエラーを特定のフィールドに表示する。",
   "Set field-level errors from server": "サーバーからのフィールドレベルエラーを設定",
+  "Saving...": "保存中...",
+  "Save": "保存",
   "Related Documentation": "関連ドキュメント",
   "API Integration Patterns": "API統合パターン",
   "API calls from forms": "フォームからのAPI呼び出し",


### PR DESCRIPTION
## Summary

- **form-handling-patterns.md**: Removed non-existent `loading` prop from shadcn/ui Button. The shadcn/ui `Button` component only supports `variant`, `size`, and `asChild` — it has no `loading` prop. Fixed to use conditional button text (`Saving...` / `Save`), which is the standard shadcn/ui pattern for loading feedback.
- **state-management-patterns.md**: Moved `fetchProducts` function inside the `useEffect` callback and added `httpClient` to the dependency array. This avoids a stale closure (the previous empty `[]` array caused `fetchProducts` to capture initial values of `httpClient` forever) and satisfies `react-hooks/exhaustive-deps` lint rules.
- **i18n**: Added English/Japanese translation keys for 'Saving...' and 'Save'.

## Test plan

- [x] `npm run translate:replace-placeholders` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)