### PR TITLE
docs: fix saas-example missing import and deployment-guide duplicate sections

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -342,13 +342,6 @@ cdk destroy dev-your-app-pipeline-stack
 - {{RDS instances with deletion protection}}
 - {{S3 buckets (must be emptied first)}}
 
-## {{Next Steps}}
-
-- {{[CI/CD with CodePipeline](/docs/codepipeline-cicd) - Automate your deployments}}
-- {{[Monitoring and Logging](/docs/monitoring-logging) - Set up observability}}
-- {{[Troubleshooting](/docs/common-issues) - Common deployment issues}}
-
-
 ## {{Related Documentation}}
 
 - [{{CI/CD with CodePipeline}}](/docs/codepipeline-cicd) - {{Automate deployments with CodePipeline}}

--- a/docs/saas-example.md
+++ b/docs/saas-example.md
@@ -172,7 +172,7 @@ export class TenantSetupService {
 
 ```typescript
 // subscription.service.ts
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
 import {
   CommandService,
   DataService,


### PR DESCRIPTION
## Summary

- **saas-example.md**: Added missing `NotFoundException` to the `SubscriptionService` import. The service throws `NotFoundException` in three places (lines 247, 287, 788) but the import at line 175 only had `BadRequestException`.

- **deployment-guide.md**: Removed the duplicate "Next Steps" section (lines 345–349) that had identical links to the existing "Related Documentation" section. Kept the more complete "Related Documentation" section which includes an extra link to Environment Variables.

## Test plan

- [x] `npm run translate:replace-placeholders` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)