### PR TITLE
docs: fix e2e-test dynamo helpers, CI workflow, controllers imports, SNS required

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -21,6 +21,8 @@ description: {{Learn how to create NestJS controllers with MBC CQRS Serverless d
 {{In the following example we'll use the `@Controller()` decorator, which is required to define a basic controller; `@Auth(ROLE_SYSTEM_ADMIN)` decorator, which is specified for authorization purpose; and `@ApiTags('cat')` to attach a controller to a specific tag.}}
 
 ```ts
+import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { ROLE_SYSTEM_ADMIN, INVOKE_CONTEXT, IInvoke, Auth } from '@mbc-cqrs-serverless/core';
 
 @Auth(ROLE_SYSTEM_ADMIN)
@@ -104,8 +106,9 @@ export class ItemController {
 {{Method decorator factory that applies standardized error response documentation. Use with Swagger response decorators to document error responses.}}
 
 ```ts
-import { SwaggerResponse } from '@mbc-cqrs-serverless/core';
+import { Controller, Get, Param } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiNotFoundResponse } from '@nestjs/swagger';
+import { SwaggerResponse } from '@mbc-cqrs-serverless/core';
 
 @Controller('items')
 export class ItemController {

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -154,7 +154,25 @@ const getItem = async (tableName: string, key: { pk: string; sk: string }) => {
   return Item ? unmarshall(Item) : undefined;
 };
 
-export { getItem, getTableName, TableType, dynamoClient };
+const putItem = async (tableName: string, item: Record<string, unknown>) => {
+  await dynamoClient.send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: marshall(item),
+    })
+  );
+};
+
+const deleteItem = async (tableName: string, key: { pk: string; sk: string }) => {
+  await dynamoClient.send(
+    new DeleteItemCommand({
+      TableName: tableName,
+      Key: marshall(key),
+    })
+  );
+};
+
+export { getItem, putItem, deleteItem, getTableName, TableType, dynamoClient };
 ```
 
 #### {{utils.ts - Test Utilities}}
@@ -319,9 +337,8 @@ on:
 
 jobs:
   e2e-tests:
-    # Configure runs-on based on your environment requirements
-    # runs-on: self-hosted  # Adjust according to your infrastructure setup
-    
+    runs-on: ubuntu-latest # {{Adjust to self-hosted if your environment requires access to private VPC resources}}
+
     steps:
       - uses: actions/checkout@v4
       

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,7 @@ description: {{Learn how to add and validate your environment variables in your 
 |-------------|-----------------|--------------|-------------|
 | `SNS_ENDPOINT` | {{SNS endpoint URL for local development}} | {{No}} | `http://localhost:4002` |
 | `SNS_REGION` | {{SNS region}} | {{No}} | `ap-northeast-1` |
-| `SNS_TOPIC_ARN` | {{Default SNS topic ARN for event notifications}} | {{Yes}} | `arn:aws:sns:ap-northeast-1:101010101010:CqrsSnsTopic` |
+| `SNS_TOPIC_ARN` | {{Default SNS topic ARN for event notifications}} | {{No}} | `arn:aws:sns:ap-northeast-1:101010101010:CqrsSnsTopic` |
 | `SNS_ALARM_TOPIC_ARN` | {{SNS topic ARN for alarm notifications (error alerts)}} | {{No}} | `arn:aws:sns:ap-northeast-1:101010101010:AlarmSnsTopic` |
 
 ### {{SQS Configuration}}

--- a/i18n/en/translation/e2e-test.json
+++ b/i18n/en/translation/e2e-test.json
@@ -61,5 +61,6 @@
   "Testing": "Testing",
   "Testing overview": "Testing overview",
   "Deployment Guide": "Deployment Guide",
-  "Deploy for integration testing": "Deploy for integration testing"
+  "Deploy for integration testing": "Deploy for integration testing",
+  "Adjust to self-hosted if your environment requires access to private VPC resources": "Adjust to self-hosted if your environment requires access to private VPC resources"
 }

--- a/i18n/ja/translation/e2e-test.json
+++ b/i18n/ja/translation/e2e-test.json
@@ -61,5 +61,6 @@
   "Testing": "テスト",
   "Testing overview": "テストの概要",
   "Deployment Guide": "デプロイガイド",
-  "Deploy for integration testing": "結合テスト用のデプロイ"
+  "Deploy for integration testing": "結合テスト用のデプロイ",
+  "Adjust to self-hosted if your environment requires access to private VPC resources": "プライベートVPCリソースへのアクセスが必要な場合はself-hostedに変更してください"
 }


### PR DESCRIPTION
## Summary

Four accuracy fixes found during documentation audit:

- **e2e-test.md**: The `dynamo-client.ts` helper example imported `PutItemCommand` and `DeleteItemCommand` but never defined or exported `putItem`/`deleteItem` functions. The test example on line 88 calls `deleteItem(...)` — which would fail at runtime. Added both functions with proper implementations and added them to the export.

- **e2e-test.md**: GitHub Actions workflow YAML was invalid — `runs-on:` was commented out entirely, which is a required field for GitHub Actions jobs. Changed to `runs-on: ubuntu-latest` with a comment to adjust for self-hosted runners.

- **controllers.md**: Two code examples used NestJS decorators (`@Controller`, `@Post`, `@Body`, `@Get`, `@Param`, `@ApiTags`) without showing their imports from `@nestjs/common` and `@nestjs/swagger`. Added the missing import statements.

- **environment-variables.md**: `SNS_TOPIC_ARN` was marked as Required: "Yes" but the framework's `env.validation.ts` does not validate it as required — it's only needed when using `SnsService`. Changed to Required: "No".

## Test plan

- [x] `npm run translate:replace-placeholders` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)