### PR TITLE
docs: fix prisma.md schema example missing model declaration

### DIFF
--- a/docs/prisma.md
+++ b/docs/prisma.md
@@ -28,34 +28,36 @@ DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection
 
 {{When creating an RDS table that maps to a DynamoDB table, ensure you add the necessary fields and indexes to the RDS table accordingly.}}
 
-```ts
-id         String   @id
-cpk        String // {{Command PK}}
-csk        String // {{Command SK}}
-pk         String // {{Data PK}}
-sk         String // {{Data SK}}
-tenantCode String   @map("tenant_code") // {{Tenant code}}
-seq        Int      @default(0) // {{Sort order, uses sequence feature}}
-code       String // {{Record code}}
-name       String // {{Record name}}
-version    Int // {{Version}}
-isDeleted  Boolean  @default(false) @map("is_deleted") // {{Deleted flag}}
-createdBy  String   @default("") @map("created_by") // {{Created by}}
-createdIp  String   @default("") @map("created_ip") // {{Created IP, supports IPv6}}
-createdAt  DateTime @default(now()) @map("created_at") @db.Timestamp(0) // {{Created at}}
-updatedBy  String   @default("") @map("updated_by") // {{Updated by}}
-updatedIp  String   @default("") @map("updated_ip") // {{Updated IP, supports IPv6}}
-updatedAt  DateTime @updatedAt @map("updated_at") @db.Timestamp(0) // {{Updated at}}
+```prisma
+model YourEntity {
+  id         String   @id
+  cpk        String // {{Command PK}}
+  csk        String // {{Command SK}}
+  pk         String // {{Data PK}}
+  sk         String // {{Data SK}}
+  tenantCode String   @map("tenant_code") // {{Tenant code}}
+  seq        Int      @default(0) // {{Sort order, uses sequence feature}}
+  code       String // {{Record code}}
+  name       String // {{Record name}}
+  version    Int // {{Version}}
+  isDeleted  Boolean  @default(false) @map("is_deleted") // {{Deleted flag}}
+  createdBy  String   @default("") @map("created_by") // {{Created by}}
+  createdIp  String   @default("") @map("created_ip") // {{Created IP, supports IPv6}}
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamp(0) // {{Created at}}
+  updatedBy  String   @default("") @map("updated_by") // {{Updated by}}
+  updatedIp  String   @default("") @map("updated_ip") // {{Updated IP, supports IPv6}}
+  updatedAt  DateTime @updatedAt @map("updated_at") @db.Timestamp(0) // {{Updated at}}
 
-// {{properties}}
+  // {{domain-specific properties}}
 
-// {{relations}}
+  // {{relations}}
 
-// {{index}}
-@@unique([cpk, csk])
-@@unique([pk, sk])
-@@unique([tenantCode, code])
-@@index([tenantCode, name])
+  // {{index}}
+  @@unique([cpk, csk])
+  @@unique([pk, sk])
+  @@unique([tenantCode, code])
+  @@index([tenantCode, name])
+}
 ```
 
 

--- a/i18n/en/translation/prisma.json
+++ b/i18n/en/translation/prisma.json
@@ -25,7 +25,6 @@
   "Updated by": "Updated by",
   "Updated IP, supports IPv6": "Updated IP, supports IPv6",
   "Updated at": "Updated at",
-  "properties": "properties",
   "relations": "relations",
   "index": "index",
   "Related Documentation": "Related Documentation",
@@ -36,5 +35,6 @@
   "Environment Variables": "Environment Variables",
   "Database connection configuration": "Database connection configuration",
   "Deployment Guide": "Deployment Guide",
-  "Database migration in deployment": "Database migration in deployment"
+  "Database migration in deployment": "Database migration in deployment",
+  "domain-specific properties": "domain-specific properties"
 }

--- a/i18n/ja/translation/prisma.json
+++ b/i18n/ja/translation/prisma.json
@@ -25,7 +25,6 @@
   "Updated by": "Updated by (更新者)",
   "Updated IP, supports IPv6": "Updated IP, supports IPv6 (更新IP、IPv6対応)",
   "Updated at": "Updated at (更新日時)",
-  "properties": "properties (プロパティ)",
   "relations": "relations (リレーション)",
   "index": "index (インデックス)",
   "Related Documentation": "関連ドキュメント",
@@ -36,5 +35,6 @@
   "Environment Variables": "環境変数",
   "Database connection configuration": "データベース接続設定",
   "Deployment Guide": "デプロイガイド",
-  "Database migration in deployment": "デプロイ時のデータベース移行"
+  "Database migration in deployment": "デプロイ時のデータベース移行",
+  "domain-specific properties": "ドメイン固有のプロパティ"
 }


### PR DESCRIPTION
## Summary

The Prisma schema template in `prisma.md` showed field definitions and `@@unique`/`@@index` model-level attributes outside of a `model` block. This is invalid Prisma schema syntax — Prisma requires all field definitions and model attributes to be inside a `model ModelName { ... }` block. Copying this snippet into `schema.prisma` would cause a parse error.

**Changes:**
- Wrapped field definitions in `model YourEntity { ... }`
- Changed code block language from `` ```ts `` to `` ```prisma `` for proper syntax highlighting
- Renamed `// properties` comment to `// domain-specific properties` for clarity

## Test plan

- [x] `npm run translate:replace-placeholders` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)