### PR TITLE
fix: correct missing imports and wrong error name in 3 docs

### DIFF
--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -44,15 +44,17 @@ await this.commandService.publishAsync({
 ### {{AP002: Ignoring Version Mismatch Errors}}
 
 :::danger {{Anti-Pattern}}
-{{Never catch and ignore VersionMismatchError without proper handling.}}
+{{Never catch and ignore ConditionalCheckFailedException without proper handling.}}
 :::
 
 ```typescript
 // ❌ {{Anti-Pattern: Silently ignoring version mismatch}}
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+
 try {
   await this.commandService.publishAsync(command, context);
 } catch (error) {
-  if (error.name === 'VersionMismatchError') {
+  if (error instanceof ConditionalCheckFailedException) {
     console.log('Version mismatch, skipping...'); // {{Silent failure!}}
   }
 }
@@ -60,6 +62,8 @@ try {
 
 ```typescript
 // ✅ {{Correct: Implement retry with fresh data}}
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+
 const MAX_RETRIES = 3;
 for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
   try {
@@ -68,7 +72,7 @@ for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     await this.commandService.publishAsync(command, context);
     break;
   } catch (error) {
-    if (error.name === 'VersionMismatchError' && attempt < MAX_RETRIES - 1) {
+    if (error instanceof ConditionalCheckFailedException && attempt < MAX_RETRIES - 1) {
       continue; // {{Retry with fresh data}}
     }
     throw error;

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -321,7 +321,7 @@ CROSS_TENANT_ROLES=system_admin,general_manager
 {{To implement custom cross-tenant access logic, extend `RolesGuard` and override the relevant methods:}}
 
 ```ts
-import { RolesGuard, getUserContext } from "@mbc-cqrs-serverless/core";
+import { RolesGuard, getUserContext, UserContext } from "@mbc-cqrs-serverless/core";
 import { ExecutionContext, Injectable } from "@nestjs/common";
 
 @Injectable()

--- a/docs/multi-tenant-patterns.md
+++ b/docs/multi-tenant-patterns.md
@@ -233,6 +233,9 @@ export interface UserTenantAssociation {
 }
 
 // user/user.service.ts
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class UserService {
   /**
@@ -316,6 +319,9 @@ export class UserService {
 
 ```typescript
 // sync/tenant-sync.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class TenantSyncService {
   private readonly logger = new Logger(TenantSyncService.name);
@@ -457,6 +463,9 @@ export class CrossTenantReportService {
 
 ```typescript
 // tenant/tenant-settings.service.ts
+import { Injectable } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class TenantSettingsService {
   private readonly settingsCache = new Map<string, TenantSettings>();

--- a/i18n/en/docusaurus-plugin-content-docs/current/anti-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/anti-patterns.md
@@ -44,15 +44,17 @@ await this.commandService.publishAsync({
 ### AP002: Ignoring Version Mismatch Errors
 
 :::danger Anti-Pattern
-Never catch and ignore VersionMismatchError without proper handling.
+Never catch and ignore ConditionalCheckFailedException without proper handling.
 :::
 
 ```typescript
 // ❌ Anti-Pattern: Silently ignoring version mismatch
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+
 try {
   await this.commandService.publishAsync(command, context);
 } catch (error) {
-  if (error.name === 'VersionMismatchError') {
+  if (error instanceof ConditionalCheckFailedException) {
     console.log('Version mismatch, skipping...'); // Silent failure!
   }
 }
@@ -60,6 +62,8 @@ try {
 
 ```typescript
 // ✅ Correct: Implement retry with fresh data
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+
 const MAX_RETRIES = 3;
 for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
   try {
@@ -68,7 +72,7 @@ for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     await this.commandService.publishAsync(command, context);
     break;
   } catch (error) {
-    if (error.name === 'VersionMismatchError' && attempt < MAX_RETRIES - 1) {
+    if (error instanceof ConditionalCheckFailedException && attempt < MAX_RETRIES - 1) {
       continue; // Retry with fresh data
     }
     throw error;

--- a/i18n/en/docusaurus-plugin-content-docs/current/authentication.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/authentication.md
@@ -321,7 +321,7 @@ CROSS_TENANT_ROLES=system_admin,general_manager
 To implement custom cross-tenant access logic, extend `RolesGuard` and override the relevant methods:
 
 ```ts
-import { RolesGuard, getUserContext } from "@mbc-cqrs-serverless/core";
+import { RolesGuard, getUserContext, UserContext } from "@mbc-cqrs-serverless/core";
 import { ExecutionContext, Injectable } from "@nestjs/common";
 
 @Injectable()

--- a/i18n/en/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
@@ -233,6 +233,9 @@ export interface UserTenantAssociation {
 }
 
 // user/user.service.ts
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class UserService {
   /**
@@ -316,6 +319,9 @@ Sync data from one tenant to another (e.g., master data distribution):
 
 ```typescript
 // sync/tenant-sync.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class TenantSyncService {
   private readonly logger = new Logger(TenantSyncService.name);
@@ -457,6 +463,9 @@ export class CrossTenantReportService {
 
 ```typescript
 // tenant/tenant-settings.service.ts
+import { Injectable } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class TenantSettingsService {
   private readonly settingsCache = new Map<string, TenantSettings>();

--- a/i18n/en/translation/anti-patterns.json
+++ b/i18n/en/translation/anti-patterns.json
@@ -14,7 +14,7 @@
   "No audit trail in command table": "No audit trail in command table",
   "Breaks CQRS pattern consistency": "Breaks CQRS pattern consistency",
   "AP002: Ignoring Version Mismatch Errors": "AP002: Ignoring Version Mismatch Errors",
-  "Never catch and ignore VersionMismatchError without proper handling.": "Never catch and ignore VersionMismatchError without proper handling.",
+  "Never catch and ignore ConditionalCheckFailedException without proper handling.": "Never catch and ignore ConditionalCheckFailedException without proper handling.",
   "Anti-Pattern: Silently ignoring version mismatch": "Anti-Pattern: Silently ignoring version mismatch",
   "Silent failure!": "Silent failure!",
   "Correct: Implement retry with fresh data": "Correct: Implement retry with fresh data",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/anti-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/anti-patterns.md
@@ -44,15 +44,17 @@ await this.commandService.publishAsync({
 ### AP002: バージョン不一致エラーの無視
 
 :::danger アンチパターン
-適切な処理なしにVersionMismatchErrorをキャッチして無視することは絶対にしないでください。
+適切な処理なしにConditionalCheckFailedExceptionをキャッチして無視することは絶対にしないでください。
 :::
 
 ```typescript
 // ❌ Anti-Pattern: Silently ignoring version mismatch (アンチパターン: バージョン不一致を黙って無視)
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+
 try {
   await this.commandService.publishAsync(command, context);
 } catch (error) {
-  if (error.name === 'VersionMismatchError') {
+  if (error instanceof ConditionalCheckFailedException) {
     console.log('Version mismatch, skipping...'); // Silent failure! (サイレント失敗！)
   }
 }
@@ -60,6 +62,8 @@ try {
 
 ```typescript
 // ✅ Correct: Implement retry with fresh data (正解: 最新データでリトライを実装)
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+
 const MAX_RETRIES = 3;
 for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
   try {
@@ -68,7 +72,7 @@ for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     await this.commandService.publishAsync(command, context);
     break;
   } catch (error) {
-    if (error.name === 'VersionMismatchError' && attempt < MAX_RETRIES - 1) {
+    if (error instanceof ConditionalCheckFailedException && attempt < MAX_RETRIES - 1) {
       continue; // Retry with fresh data (最新データでリトライ)
     }
     throw error;

--- a/i18n/ja/docusaurus-plugin-content-docs/current/authentication.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/authentication.md
@@ -321,7 +321,7 @@ CROSS_TENANT_ROLES=system_admin,general_manager
 カスタムクロステナントアクセスロジックを実装するには、`RolesGuard`を拡張して関連メソッドをオーバーライドします：
 
 ```ts
-import { RolesGuard, getUserContext } from "@mbc-cqrs-serverless/core";
+import { RolesGuard, getUserContext, UserContext } from "@mbc-cqrs-serverless/core";
 import { ExecutionContext, Injectable } from "@nestjs/common";
 
 @Injectable()

--- a/i18n/ja/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
@@ -233,6 +233,9 @@ export interface UserTenantAssociation {
 }
 
 // user/user.service.ts
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class UserService {
   /**
@@ -316,6 +319,9 @@ export class UserService {
 
 ```typescript
 // sync/tenant-sync.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class TenantSyncService {
   private readonly logger = new Logger(TenantSyncService.name);
@@ -457,6 +463,9 @@ export class CrossTenantReportService {
 
 ```typescript
 // tenant/tenant-settings.service.ts
+import { Injectable } from '@nestjs/common';
+import { CommandService, DataService, IInvoke, KEY_SEPARATOR, generateId } from '@mbc-cqrs-serverless/core';
+
 @Injectable()
 export class TenantSettingsService {
   private readonly settingsCache = new Map<string, TenantSettings>();

--- a/i18n/ja/translation/anti-patterns.json
+++ b/i18n/ja/translation/anti-patterns.json
@@ -14,7 +14,7 @@
   "No audit trail in command table": "コマンドテーブルに監査証跡が残らない",
   "Breaks CQRS pattern consistency": "CQRSパターンの一貫性を壊す",
   "AP002: Ignoring Version Mismatch Errors": "AP002: バージョン不一致エラーの無視",
-  "Never catch and ignore VersionMismatchError without proper handling.": "適切な処理なしにVersionMismatchErrorをキャッチして無視することは絶対にしないでください。",
+  "Never catch and ignore ConditionalCheckFailedException without proper handling.": "適切な処理なしにConditionalCheckFailedExceptionをキャッチして無視することは絶対にしないでください。",
   "Anti-Pattern: Silently ignoring version mismatch": "Anti-Pattern: Silently ignoring version mismatch (アンチパターン: バージョン不一致を黙って無視)",
   "Silent failure!": "Silent failure! (サイレント失敗！)",
   "Correct: Implement retry with fresh data": "Correct: Implement retry with fresh data (正解: 最新データでリトライを実装)",


### PR DESCRIPTION
## Summary

- **authentication.md**: Added `UserContext` to import from `@mbc-cqrs-serverless/core` — it was used as a type parameter but missing from the import statement
- **anti-patterns.md (AP002)**: Replaced the non-existent `VersionMismatchError` with the real `ConditionalCheckFailedException` from `@aws-sdk/client-dynamodb` in both the ❌ anti-pattern and ✅ correct retry examples; updated description text and translation JSON files (en + ja)
- **multi-tenant-patterns.md**: Added missing imports to three complete `@Injectable()` class examples (`UserService`, `TenantSyncService`, `TenantSettingsService`) which all used `KEY_SEPARATOR`, `generateId`, `IInvoke`, `CommandService`, `DataService` without importing them

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)