### PR TITLE
fix: correct missing imports in version-conflict-guide, ecommerce, and saas docs

### DIFF
--- a/docs/ecommerce-example.md
+++ b/docs/ecommerce-example.md
@@ -286,7 +286,10 @@ export class OrderController {
 // inventory.service.ts
 import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
-import { CommandService, DataService, IInvoke, getUserContext, generatePk } from '@mbc-cqrs-serverless/core';
+import { CommandService, DataService, IInvoke, getUserContext, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
+
+const generatePk = (tenantCode: string): string =>
+  `TENANT${KEY_SEPARATOR}${tenantCode}`;
 
 @Injectable()
 export class InventoryService {

--- a/docs/saas-example.md
+++ b/docs/saas-example.md
@@ -88,7 +88,7 @@ export interface UsageAttributes {
 ```typescript
 // tenant-setup.service.ts
 import { Injectable } from '@nestjs/common';
-import { IInvoke, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
+import { CommandService, IInvoke, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
 import { TenantService } from '@mbc-cqrs-serverless/tenant';
 import { SubscriptionService } from './subscription.service';
 
@@ -102,6 +102,7 @@ export class TenantSetupService {
   constructor(
     private readonly tenantService: TenantService,
     private readonly subscriptionService: SubscriptionService,
+    private readonly commandService: CommandService,
   ) {}
 
   // {{Create tenant with initial subscription}}
@@ -551,6 +552,7 @@ import {
   KEY_SEPARATOR,
 } from '@mbc-cqrs-serverless/core';
 import { MasterDataService } from '@mbc-cqrs-serverless/master';
+import { BillingService } from './billing.service';
 
 @DataSyncHandler('subscription')
 @Injectable()

--- a/docs/version-conflict-guide.md
+++ b/docs/version-conflict-guide.md
@@ -84,7 +84,7 @@ await this.commandService.publishPartialUpdateAsync(updateCommand, {
 {{When you want to always update the latest version without worrying about the exact version number:}}
 
 ```typescript
-import { VERSION_LATEST, CommandInputModel } from '@mbc-cqrs-serverless/core';
+import { VERSION_LATEST, CommandInputModel, generateId } from '@mbc-cqrs-serverless/core';
 
 const command: CommandInputModel = {
   pk: catPk,
@@ -108,7 +108,7 @@ await this.commandService.publishAsync(command, {
 {{When creating new items, use VERSION_FIRST (0) to indicate this is the first version:}}
 
 ```typescript
-import { VERSION_FIRST, CommandDto } from '@mbc-cqrs-serverless/core';
+import { VERSION_FIRST, CommandDto, generateId } from '@mbc-cqrs-serverless/core';
 
 const newCatCommand = new CatCommandDto({
   pk: catPk,
@@ -135,6 +135,14 @@ await this.commandService.publishAsync(newCatCommand, {
 
 ```typescript
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import {
+  CommandService,
+  DataService,
+  IInvoke,
+  VERSION_FIRST,
+  CommandInputModel,
+  CommandPartialInputModel,
+} from '@mbc-cqrs-serverless/core';
 
 async function updateWithRetry(
   commandService: CommandService,

--- a/i18n/en/docusaurus-plugin-content-docs/current/ecommerce-example.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ecommerce-example.md
@@ -286,7 +286,10 @@ export class OrderController {
 // inventory.service.ts
 import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
-import { CommandService, DataService, IInvoke, getUserContext, generatePk } from '@mbc-cqrs-serverless/core';
+import { CommandService, DataService, IInvoke, getUserContext, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
+
+const generatePk = (tenantCode: string): string =>
+  `TENANT${KEY_SEPARATOR}${tenantCode}`;
 
 @Injectable()
 export class InventoryService {

--- a/i18n/en/docusaurus-plugin-content-docs/current/saas-example.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/saas-example.md
@@ -88,7 +88,7 @@ export interface UsageAttributes {
 ```typescript
 // tenant-setup.service.ts
 import { Injectable } from '@nestjs/common';
-import { IInvoke, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
+import { CommandService, IInvoke, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
 import { TenantService } from '@mbc-cqrs-serverless/tenant';
 import { SubscriptionService } from './subscription.service';
 
@@ -102,6 +102,7 @@ export class TenantSetupService {
   constructor(
     private readonly tenantService: TenantService,
     private readonly subscriptionService: SubscriptionService,
+    private readonly commandService: CommandService,
   ) {}
 
   // Create tenant with initial subscription
@@ -551,6 +552,7 @@ import {
   KEY_SEPARATOR,
 } from '@mbc-cqrs-serverless/core';
 import { MasterDataService } from '@mbc-cqrs-serverless/master';
+import { BillingService } from './billing.service';
 
 @DataSyncHandler('subscription')
 @Injectable()

--- a/i18n/en/docusaurus-plugin-content-docs/current/version-conflict-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/version-conflict-guide.md
@@ -84,7 +84,7 @@ await this.commandService.publishPartialUpdateAsync(updateCommand, {
 When you want to always update the latest version without worrying about the exact version number:
 
 ```typescript
-import { VERSION_LATEST, CommandInputModel } from '@mbc-cqrs-serverless/core';
+import { VERSION_LATEST, CommandInputModel, generateId } from '@mbc-cqrs-serverless/core';
 
 const command: CommandInputModel = {
   pk: catPk,
@@ -108,7 +108,7 @@ await this.commandService.publishAsync(command, {
 When creating new items, use VERSION_FIRST (0) to indicate this is the first version:
 
 ```typescript
-import { VERSION_FIRST, CommandDto } from '@mbc-cqrs-serverless/core';
+import { VERSION_FIRST, CommandDto, generateId } from '@mbc-cqrs-serverless/core';
 
 const newCatCommand = new CatCommandDto({
   pk: catPk,
@@ -135,6 +135,14 @@ Implement retry logic to handle transient conflicts:
 
 ```typescript
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import {
+  CommandService,
+  DataService,
+  IInvoke,
+  VERSION_FIRST,
+  CommandInputModel,
+  CommandPartialInputModel,
+} from '@mbc-cqrs-serverless/core';
 
 async function updateWithRetry(
   commandService: CommandService,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ecommerce-example.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ecommerce-example.md
@@ -286,7 +286,10 @@ export class OrderController {
 // inventory.service.ts
 import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
-import { CommandService, DataService, IInvoke, getUserContext, generatePk } from '@mbc-cqrs-serverless/core';
+import { CommandService, DataService, IInvoke, getUserContext, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
+
+const generatePk = (tenantCode: string): string =>
+  `TENANT${KEY_SEPARATOR}${tenantCode}`;
 
 @Injectable()
 export class InventoryService {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/saas-example.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/saas-example.md
@@ -88,7 +88,7 @@ export interface UsageAttributes {
 ```typescript
 // tenant-setup.service.ts
 import { Injectable } from '@nestjs/common';
-import { IInvoke, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
+import { CommandService, IInvoke, KEY_SEPARATOR } from '@mbc-cqrs-serverless/core';
 import { TenantService } from '@mbc-cqrs-serverless/tenant';
 import { SubscriptionService } from './subscription.service';
 
@@ -102,6 +102,7 @@ export class TenantSetupService {
   constructor(
     private readonly tenantService: TenantService,
     private readonly subscriptionService: SubscriptionService,
+    private readonly commandService: CommandService,
   ) {}
 
   // Create tenant with initial subscription (初期サブスクリプション付きでテナントを作成)
@@ -551,6 +552,7 @@ import {
   KEY_SEPARATOR,
 } from '@mbc-cqrs-serverless/core';
 import { MasterDataService } from '@mbc-cqrs-serverless/master';
+import { BillingService } from './billing.service';
 
 @DataSyncHandler('subscription')
 @Injectable()

--- a/i18n/ja/docusaurus-plugin-content-docs/current/version-conflict-guide.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/version-conflict-guide.md
@@ -84,7 +84,7 @@ await this.commandService.publishPartialUpdateAsync(updateCommand, {
 正確なバージョン番号を気にせずに常に最新バージョンを更新したい場合：
 
 ```typescript
-import { VERSION_LATEST, CommandInputModel } from '@mbc-cqrs-serverless/core';
+import { VERSION_LATEST, CommandInputModel, generateId } from '@mbc-cqrs-serverless/core';
 
 const command: CommandInputModel = {
   pk: catPk,
@@ -108,7 +108,7 @@ await this.commandService.publishAsync(command, {
 新規アイテムを作成する際は、VERSION_FIRST（0）を使用して最初のバージョンであることを示します：
 
 ```typescript
-import { VERSION_FIRST, CommandDto } from '@mbc-cqrs-serverless/core';
+import { VERSION_FIRST, CommandDto, generateId } from '@mbc-cqrs-serverless/core';
 
 const newCatCommand = new CatCommandDto({
   pk: catPk,
@@ -135,6 +135,14 @@ await this.commandService.publishAsync(newCatCommand, {
 
 ```typescript
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import {
+  CommandService,
+  DataService,
+  IInvoke,
+  VERSION_FIRST,
+  CommandInputModel,
+  CommandPartialInputModel,
+} from '@mbc-cqrs-serverless/core';
 
 async function updateWithRetry(
   commandService: CommandService,


### PR DESCRIPTION
## Summary

- **version-conflict-guide.md**: Added `generateId` to the VERSION_LATEST and VERSION_FIRST code examples; added full import block to the retry logic example (was only importing `ConditionalCheckFailedException` but also used `CommandService`, `DataService`, `IInvoke`, `VERSION_FIRST`, `CommandInputModel`, `CommandPartialInputModel`)
- **ecommerce-example.md**: Removed non-existent `generatePk` from the `@mbc-cqrs-serverless/core` import (it is not exported from core) and replaced with a local helper function using `KEY_SEPARATOR`
- **saas-example.md**: Added `CommandService` to the `TenantSetupService` import and constructor (it was used via `this.commandService` but never declared); added `BillingService` import to `BillingEventHandler` (used in constructor injection but the import was missing)

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)