### PR TITLE
fix: correct return type and missing imports in 3 docs

### DIFF
--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -263,7 +263,7 @@ export class ProductService {
   async create(
     createDto: { name: string; description?: string },
     opts: { invokeContext: IInvoke },
-  ): Promise<ProductDataEntity> {
+  ): Promise<ProductDataEntity | null> {
     const { tenantCode } = getUserContext(opts.invokeContext);
 
     const pk = `${PRODUCT_PK_PREFIX}${KEY_SEPARATOR}${tenantCode}`;

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -167,7 +167,7 @@ const userPool = new cognito.UserPool(this, 'UserPool', {
 {{Always validate JWT tokens on the server side.}}
 
 ```typescript
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 
 @Injectable()

--- a/docs/survey-template.md
+++ b/docs/survey-template.md
@@ -214,6 +214,9 @@ async deleteTemplate(
 {{Templates are automatically isolated by tenant through the invoke context:}}
 
 ```typescript
+import { Controller, Get, Query } from '@nestjs/common';
+import { getUserContext, IInvoke, INVOKE_CONTEXT } from '@mbc-cqrs-serverless/core';
+
 @Controller('api/survey-template')
 export class SurveyTemplateController {
   constructor(

--- a/i18n/en/docusaurus-plugin-content-docs/current/backend-development.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/backend-development.md
@@ -263,7 +263,7 @@ export class ProductService {
   async create(
     createDto: { name: string; description?: string },
     opts: { invokeContext: IInvoke },
-  ): Promise<ProductDataEntity> {
+  ): Promise<ProductDataEntity | null> {
     const { tenantCode } = getUserContext(opts.invokeContext);
 
     const pk = `${PRODUCT_PK_PREFIX}${KEY_SEPARATOR}${tenantCode}`;

--- a/i18n/en/docusaurus-plugin-content-docs/current/security-best-practices.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/security-best-practices.md
@@ -167,7 +167,7 @@ The default implementation uses `minLength: 6` for development convenience. For 
 Always validate JWT tokens on the server side.
 
 ```typescript
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 
 @Injectable()

--- a/i18n/en/docusaurus-plugin-content-docs/current/survey-template.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/survey-template.md
@@ -214,6 +214,9 @@ async deleteTemplate(
 Templates are automatically isolated by tenant through the invoke context:
 
 ```typescript
+import { Controller, Get, Query } from '@nestjs/common';
+import { getUserContext, IInvoke, INVOKE_CONTEXT } from '@mbc-cqrs-serverless/core';
+
 @Controller('api/survey-template')
 export class SurveyTemplateController {
   constructor(

--- a/i18n/ja/docusaurus-plugin-content-docs/current/backend-development.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/backend-development.md
@@ -263,7 +263,7 @@ export class ProductService {
   async create(
     createDto: { name: string; description?: string },
     opts: { invokeContext: IInvoke },
-  ): Promise<ProductDataEntity> {
+  ): Promise<ProductDataEntity | null> {
     const { tenantCode } = getUserContext(opts.invokeContext);
 
     const pk = `${PRODUCT_PK_PREFIX}${KEY_SEPARATOR}${tenantCode}`;

--- a/i18n/ja/docusaurus-plugin-content-docs/current/security-best-practices.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/security-best-practices.md
@@ -167,7 +167,7 @@ const userPool = new cognito.UserPool(this, 'UserPool', {
 サーバー側で常にJWTトークンをバリデーションします。
 
 ```typescript
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 
 @Injectable()

--- a/i18n/ja/docusaurus-plugin-content-docs/current/survey-template.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/survey-template.md
@@ -214,6 +214,9 @@ async deleteTemplate(
 テンプレートはinvokeコンテキストを通じてテナントごとに自動的に分離されます：
 
 ```typescript
+import { Controller, Get, Query } from '@nestjs/common';
+import { getUserContext, IInvoke, INVOKE_CONTEXT } from '@mbc-cqrs-serverless/core';
+
 @Controller('api/survey-template')
 export class SurveyTemplateController {
   constructor(


### PR DESCRIPTION
## Summary

- **backend-development.md**: Changed `create()` method return type from `Promise<ProductDataEntity>` to `Promise<ProductDataEntity | null>` — `publishAsync` returns null for no-op since v1.2.0, and the code already handles this with `if (!item) return null`
- **security-best-practices.md**: Added `UnauthorizedException` to the `JwtAuthGuard` import from `@nestjs/common` — used in `canActivate()` at two places but was missing from the import statement
- **survey-template.md**: Added framework imports to the multi-tenant controller example (`Controller`, `Get`, `Query` from `@nestjs/common`; `getUserContext`, `IInvoke`, `INVOKE_CONTEXT` from `@mbc-cqrs-serverless/core`)

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)