### PR TITLE
fix: correct ComparisonStatus.EQUAL bug and undefined ENVIRONMENT variable

### DIFF
--- a/docs/codepipeline-cicd.md
+++ b/docs/codepipeline-cicd.md
@@ -166,6 +166,7 @@ version: 0.2
 env:
   variables:
     NODE_ENV: production
+    ENVIRONMENT: production
   parameter-store:
     DATABASE_URL: /your-app/database-url
   secrets-manager:

--- a/docs/import-export-patterns.md
+++ b/docs/import-export-patterns.md
@@ -1283,7 +1283,7 @@ export class PolicyProcessStrategy
   ): Promise<ComparisonResult<PolicyDataEntity>> {
     const existing = await this.dataService.getItem({ pk: dto.pk, sk: dto.sk });
     if (!existing) return { status: ComparisonStatus.NOT_EXIST };
-    return { status: ComparisonStatus.EQUAL, existingData: existing as PolicyDataEntity };
+    return { status: ComparisonStatus.CHANGED, existingData: existing as PolicyDataEntity };
   }
 
   async map(

--- a/i18n/en/docusaurus-plugin-content-docs/current/codepipeline-cicd.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/codepipeline-cicd.md
@@ -166,6 +166,7 @@ version: 0.2
 env:
   variables:
     NODE_ENV: production
+    ENVIRONMENT: production
   parameter-store:
     DATABASE_URL: /your-app/database-url
   secrets-manager:

--- a/i18n/en/docusaurus-plugin-content-docs/current/import-export-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/import-export-patterns.md
@@ -1283,7 +1283,7 @@ export class PolicyProcessStrategy
   ): Promise<ComparisonResult<PolicyDataEntity>> {
     const existing = await this.dataService.getItem({ pk: dto.pk, sk: dto.sk });
     if (!existing) return { status: ComparisonStatus.NOT_EXIST };
-    return { status: ComparisonStatus.EQUAL, existingData: existing as PolicyDataEntity };
+    return { status: ComparisonStatus.CHANGED, existingData: existing as PolicyDataEntity };
   }
 
   async map(

--- a/i18n/ja/docusaurus-plugin-content-docs/current/codepipeline-cicd.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/codepipeline-cicd.md
@@ -166,6 +166,7 @@ version: 0.2
 env:
   variables:
     NODE_ENV: production
+    ENVIRONMENT: production
   parameter-store:
     DATABASE_URL: /your-app/database-url
   secrets-manager:

--- a/i18n/ja/docusaurus-plugin-content-docs/current/import-export-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/import-export-patterns.md
@@ -1283,7 +1283,7 @@ export class PolicyProcessStrategy
   ): Promise<ComparisonResult<PolicyDataEntity>> {
     const existing = await this.dataService.getItem({ pk: dto.pk, sk: dto.sk });
     if (!existing) return { status: ComparisonStatus.NOT_EXIST };
-    return { status: ComparisonStatus.EQUAL, existingData: existing as PolicyDataEntity };
+    return { status: ComparisonStatus.CHANGED, existingData: existing as PolicyDataEntity };
   }
 
   async map(


### PR DESCRIPTION
## Summary

- **import-export-patterns.md**: Fixed `PolicyProcessStrategy.compare()` returning `ComparisonStatus.EQUAL` for existing items — this caused the import to silently skip all updates to existing policies because `map()` only handles `NOT_EXIST` and `CHANGED` (the signature is `Exclude<ComparisonStatus, ComparisonStatus.EQUAL>`). The comment at line 1299 explicitly says "status === ComparisonStatus.CHANGED". Changed to `CHANGED` so updates actually propagate.
- **codepipeline-cicd.md**: Added `ENVIRONMENT: production` to the `env.variables` block in the BuildSpec example — the `$ENVIRONMENT` variable was used in `npx cdk synth --context env=$ENVIRONMENT` but never declared, so the context value would be empty at runtime.

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)