### PR TITLE
fix: correct master.md update/delete return types to CommandModel | null

### DIFF
--- a/docs/master.md
+++ b/docs/master.md
@@ -251,7 +251,7 @@ const settings = await this.masterSettingService.createBulk(
 );
 ```
 
-#### `update(key: DetailDto, updateDto: MasterSettingUpdateDto, invokeContext: IInvoke): Promise<CommandModel>`
+#### `update(key: DetailDto, updateDto: MasterSettingUpdateDto, invokeContext: IInvoke): Promise<CommandModel | null>`
 {{Updates a master setting.}}
 ```ts
 const result = await this.masterSettingService.update(
@@ -264,7 +264,7 @@ const result = await this.masterSettingService.update(
 );
 ```
 
-#### `delete(key: DetailDto, invokeContext: IInvoke): Promise<CommandModel>`
+#### `delete(key: DetailDto, invokeContext: IInvoke): Promise<CommandModel | null>`
 {{Deletes a master setting. Wrapper for deleteSetting.}}
 ```ts
 await this.masterSettingService.delete(

--- a/i18n/en/docusaurus-plugin-content-docs/current/master.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/master.md
@@ -251,7 +251,7 @@ const settings = await this.masterSettingService.createBulk(
 );
 ```
 
-#### `update(key: DetailDto, updateDto: MasterSettingUpdateDto, invokeContext: IInvoke): Promise<CommandModel>`
+#### `update(key: DetailDto, updateDto: MasterSettingUpdateDto, invokeContext: IInvoke): Promise<CommandModel | null>`
 Updates a master setting.
 ```ts
 const result = await this.masterSettingService.update(
@@ -264,7 +264,7 @@ const result = await this.masterSettingService.update(
 );
 ```
 
-#### `delete(key: DetailDto, invokeContext: IInvoke): Promise<CommandModel>`
+#### `delete(key: DetailDto, invokeContext: IInvoke): Promise<CommandModel | null>`
 Deletes a master setting. Wrapper for deleteSetting.
 ```ts
 await this.masterSettingService.delete(

--- a/i18n/ja/docusaurus-plugin-content-docs/current/master.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/master.md
@@ -251,7 +251,7 @@ const settings = await this.masterSettingService.createBulk(
 );
 ```
 
-#### `update(key: DetailDto, updateDto: MasterSettingUpdateDto, invokeContext: IInvoke): Promise<CommandModel>`
+#### `update(key: DetailDto, updateDto: MasterSettingUpdateDto, invokeContext: IInvoke): Promise<CommandModel | null>`
 マスター設定を更新します。
 ```ts
 const result = await this.masterSettingService.update(
@@ -264,7 +264,7 @@ const result = await this.masterSettingService.update(
 );
 ```
 
-#### `delete(key: DetailDto, invokeContext: IInvoke): Promise<CommandModel>`
+#### `delete(key: DetailDto, invokeContext: IInvoke): Promise<CommandModel | null>`
 マスター設定を削除します。deleteSettingのラッパーです。
 ```ts
 await this.masterSettingService.delete(


### PR DESCRIPTION
## Summary

`MasterSettingService.update()` and `delete()` are both documented with return type `Promise<CommandModel>`, but they delegate to `publishPartialUpdateAsync()` which returns `Promise<CommandModel | null>` since v1.2.0 (null is returned when no changes are detected). Fixed both signatures to `Promise<CommandModel | null>` to accurately reflect the possible null return.

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)