### PR TITLE
fix: correct sk version separator and ttl description in interfaces.md

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -18,7 +18,7 @@ description: {{Complete reference of TypeScript interfaces used in MBC CQRS Serv
 ```ts
 export interface CommandInputModel {
   pk: string              // Partition key (e.g., "ORDER#tenant001")
-  sk: string              // Sort key with version (e.g., "ORDER#ORD001#v0")
+  sk: string              // Sort key with version (e.g., "ORDER#ORD001@1")
   id: string              // Unique identifier (e.g., UUID)
   code: string            // Business code (e.g., "ORD001")
   name: string            // Display name
@@ -27,7 +27,7 @@ export interface CommandInputModel {
   type: string            // Entity type (e.g., "ORDER")
   isDeleted?: boolean     // Soft delete flag
   seq?: number            // Sequence number (auto-generated)
-  ttl?: number            // Time-to-live timestamp (Unix epoch)
+  ttl?: number            // Time-to-live in seconds
   attributes?: Record<string, any>  // Custom domain attributes
 }
 ```
@@ -36,7 +36,7 @@ export interface CommandInputModel {
 ```typescript
 const orderInput: CommandInputModel = {
   pk: 'ORDER#tenant001',
-  sk: 'ORDER#ORD001#v0',
+  sk: 'ORDER#ORD001@1',
   id: crypto.randomUUID(),
   code: 'ORD001',
   name: 'Customer Order',

--- a/i18n/en/docusaurus-plugin-content-docs/current/interfaces.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/interfaces.md
@@ -18,7 +18,7 @@ The primary interface for creating new commands. Used when publishing new entiti
 ```ts
 export interface CommandInputModel {
   pk: string              // Partition key (e.g., "ORDER#tenant001")
-  sk: string              // Sort key with version (e.g., "ORDER#ORD001#v0")
+  sk: string              // Sort key with version (e.g., "ORDER#ORD001@1")
   id: string              // Unique identifier (e.g., UUID)
   code: string            // Business code (e.g., "ORD001")
   name: string            // Display name
@@ -27,7 +27,7 @@ export interface CommandInputModel {
   type: string            // Entity type (e.g., "ORDER")
   isDeleted?: boolean     // Soft delete flag
   seq?: number            // Sequence number (auto-generated)
-  ttl?: number            // Time-to-live timestamp (Unix epoch)
+  ttl?: number            // Time-to-live in seconds
   attributes?: Record<string, any>  // Custom domain attributes
 }
 ```
@@ -36,7 +36,7 @@ export interface CommandInputModel {
 ```typescript
 const orderInput: CommandInputModel = {
   pk: 'ORDER#tenant001',
-  sk: 'ORDER#ORD001#v0',
+  sk: 'ORDER#ORD001@1',
   id: crypto.randomUUID(),
   code: 'ORD001',
   name: 'Customer Order',

--- a/i18n/ja/docusaurus-plugin-content-docs/current/interfaces.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/interfaces.md
@@ -18,7 +18,7 @@ description: MBC CQRS Serverlessフレームワークで使用されるTypeScrip
 ```ts
 export interface CommandInputModel {
   pk: string              // Partition key (e.g., "ORDER#tenant001")
-  sk: string              // Sort key with version (e.g., "ORDER#ORD001#v0")
+  sk: string              // Sort key with version (e.g., "ORDER#ORD001@1")
   id: string              // Unique identifier (e.g., UUID)
   code: string            // Business code (e.g., "ORD001")
   name: string            // Display name
@@ -27,7 +27,7 @@ export interface CommandInputModel {
   type: string            // Entity type (e.g., "ORDER")
   isDeleted?: boolean     // Soft delete flag
   seq?: number            // Sequence number (auto-generated)
-  ttl?: number            // Time-to-live timestamp (Unix epoch)
+  ttl?: number            // Time-to-live in seconds
   attributes?: Record<string, any>  // Custom domain attributes
 }
 ```
@@ -36,7 +36,7 @@ export interface CommandInputModel {
 ```typescript
 const orderInput: CommandInputModel = {
   pk: 'ORDER#tenant001',
-  sk: 'ORDER#ORD001#v0',
+  sk: 'ORDER#ORD001@1',
   id: crypto.randomUUID(),
   code: 'ORD001',
   name: 'Customer Order',


### PR DESCRIPTION
## Summary

- **sk format**: Changed example from `"ORDER#ORD001#v0"` to `"ORDER#ORD001@1"` — the version separator is `VER_SEPARATOR` which is `'@'`, not `'#'`, and the suffix is the numeric version number (not a `v`-prefixed string). Confirmed in `command-model.interface.ts` JSDoc.
- **ttl field**: Changed description from "Time-to-live timestamp (Unix epoch)" to "Time-to-live in seconds" — the field stores a duration in seconds, not an absolute Unix epoch timestamp. Confirmed in `command-input-model.interface.ts` JSDoc which says "Time-to-live in seconds".

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)