### PR TITLE
fix: use definitionBody API and add missing UI imports in 2 docs

### DIFF
--- a/docs/architecture/step-functions.md
+++ b/docs/architecture/step-functions.md
@@ -392,7 +392,7 @@ export class TaskStateMachineConstruct extends Construct {
     this.stateMachine = new sfn.StateMachine(this, 'TaskHandlerStateMachine', {
       stateMachineName: 'task-handler',
       comment: 'Handles parallel task execution with concurrency control',
-      definition: mapState,
+      definitionBody: sfn.DefinitionBody.fromChainable(mapState),
       timeout: cdk.Duration.minutes(15),
       tracingEnabled: true,
       logs: {
@@ -989,7 +989,7 @@ private async triggerSingleCsvJob(event: ZipImportSfnEvent) {
 ```typescript
 const taskStateMachine = new sfn.StateMachine(this, 'task-handler', {
   stateMachineName: 'task-handler',
-  definition: sfnTaskMapState,
+  definitionBody: sfn.DefinitionBody.fromChainable(sfnTaskMapState),
   timeout: cdk.Duration.minutes(15), // {{Overall workflow timeout}}
   tracingEnabled: true,
   logs: {

--- a/docs/form-handling-patterns.md
+++ b/docs/form-handling-patterns.md
@@ -568,6 +568,8 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 
 const orderItemSchema = z.object({
   productId: z.string().min(1, 'Product is required'),
@@ -689,6 +691,14 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 function PaymentForm() {
   const form = useForm({
@@ -823,6 +833,8 @@ import { useProduct, useUpdateProduct } from '@/hooks/useProducts';
 import { ProductForm } from '@/components/forms/ProductForm';
 import { UpdateProductInput } from '@/schemas/product.schema';
 import { toast } from '@/components/ui/toast';
+import { Skeleton } from '@/components/ui/skeleton';
+import { NotFound } from '@/components/not-found';
 
 interface EditProductFormProps {
   pk: string;

--- a/i18n/en/docusaurus-plugin-content-docs/current/architecture/step-functions.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/architecture/step-functions.md
@@ -392,7 +392,7 @@ export class TaskStateMachineConstruct extends Construct {
     this.stateMachine = new sfn.StateMachine(this, 'TaskHandlerStateMachine', {
       stateMachineName: 'task-handler',
       comment: 'Handles parallel task execution with concurrency control',
-      definition: mapState,
+      definitionBody: sfn.DefinitionBody.fromChainable(mapState),
       timeout: cdk.Duration.minutes(15),
       tracingEnabled: true,
       logs: {
@@ -989,7 +989,7 @@ Set appropriate timeouts for long-running workflows:
 ```typescript
 const taskStateMachine = new sfn.StateMachine(this, 'task-handler', {
   stateMachineName: 'task-handler',
-  definition: sfnTaskMapState,
+  definitionBody: sfn.DefinitionBody.fromChainable(sfnTaskMapState),
   timeout: cdk.Duration.minutes(15), // Overall workflow timeout
   tracingEnabled: true,
   logs: {

--- a/i18n/en/docusaurus-plugin-content-docs/current/form-handling-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/form-handling-patterns.md
@@ -568,6 +568,8 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 
 const orderItemSchema = z.object({
   productId: z.string().min(1, 'Product is required'),
@@ -689,6 +691,14 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 function PaymentForm() {
   const form = useForm({
@@ -823,6 +833,8 @@ import { useProduct, useUpdateProduct } from '@/hooks/useProducts';
 import { ProductForm } from '@/components/forms/ProductForm';
 import { UpdateProductInput } from '@/schemas/product.schema';
 import { toast } from '@/components/ui/toast';
+import { Skeleton } from '@/components/ui/skeleton';
+import { NotFound } from '@/components/not-found';
 
 interface EditProductFormProps {
   pk: string;

--- a/i18n/ja/docusaurus-plugin-content-docs/current/architecture/step-functions.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/architecture/step-functions.md
@@ -392,7 +392,7 @@ export class TaskStateMachineConstruct extends Construct {
     this.stateMachine = new sfn.StateMachine(this, 'TaskHandlerStateMachine', {
       stateMachineName: 'task-handler',
       comment: 'Handles parallel task execution with concurrency control',
-      definition: mapState,
+      definitionBody: sfn.DefinitionBody.fromChainable(mapState),
       timeout: cdk.Duration.minutes(15),
       tracingEnabled: true,
       logs: {
@@ -989,7 +989,7 @@ private async triggerSingleCsvJob(event: ZipImportSfnEvent) {
 ```typescript
 const taskStateMachine = new sfn.StateMachine(this, 'task-handler', {
   stateMachineName: 'task-handler',
-  definition: sfnTaskMapState,
+  definitionBody: sfn.DefinitionBody.fromChainable(sfnTaskMapState),
   timeout: cdk.Duration.minutes(15), // Overall workflow timeout (全体のワークフロータイムアウト)
   tracingEnabled: true,
   logs: {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/form-handling-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/form-handling-patterns.md
@@ -568,6 +568,8 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 
 const orderItemSchema = z.object({
   productId: z.string().min(1, 'Product is required'),
@@ -689,6 +691,14 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 function PaymentForm() {
   const form = useForm({
@@ -823,6 +833,8 @@ import { useProduct, useUpdateProduct } from '@/hooks/useProducts';
 import { ProductForm } from '@/components/forms/ProductForm';
 import { UpdateProductInput } from '@/schemas/product.schema';
 import { toast } from '@/components/ui/toast';
+import { Skeleton } from '@/components/ui/skeleton';
+import { NotFound } from '@/components/not-found';
 
 interface EditProductFormProps {
   pk: string;


### PR DESCRIPTION
## Summary

- **architecture/step-functions.md**: Replaced the deprecated `definition:` property with `definitionBody: sfn.DefinitionBody.fromChainable()` in two `sfn.StateMachine` examples (TaskStateMachine and workflow timeout example). The `CommandHandlerStateMachine` example already used the correct API — these two were inconsistent. The `definition` property was removed in CDK v2 in favor of `definitionBody`.
- **form-handling-patterns.md**: Added missing UI component imports to three complete component examples:
  - `OrderForm`: Added `Input` and `Button` from `@/components/ui/*`
  - `PaymentForm`: Added `Input`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` from `@/components/ui/*`
  - `EditProductForm`: Added `Skeleton` and `NotFound` components

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)