### PR TITLE
fix: return type, missing imports, and undefined function in 3 docs

### DIFF
--- a/docs/api-integration-patterns.md
+++ b/docs/api-integration-patterns.md
@@ -158,6 +158,7 @@ export class ProductService {
 // src/lib/api/client.ts
 import { client } from '@/services/sdk/client';
 import { fetchAuthSession } from 'aws-amplify/auth';
+import { getTenantCode as getTenantFromStore } from '@/store/tenant';
 
 // {{Configure the base URL}}
 client.setConfig({

--- a/docs/frontend-project-structure.md
+++ b/docs/frontend-project-structure.md
@@ -290,8 +290,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 import { useProducts } from '@/hooks/useProducts';
 import { ProductTable } from '@/components/products/ProductTable';
-import { Button } from '@/components/ui/Button';
+import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { ErrorMessage } from '@/components/ui/error-message';
 
 export function ProductList() {
   const router = useRouter();

--- a/docs/import.md
+++ b/docs/import.md
@@ -188,7 +188,7 @@ await this.importService.updateStatus(
 );
 ```
 
-#### `getImportByKey(key: DetailKey): Promise<ImportEntity>`
+#### `getImportByKey(key: DetailKey): Promise<ImportEntity | null>`
 
 {{Retrieves an import entity by its key.}}
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/api-integration-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/api-integration-patterns.md
@@ -158,6 +158,7 @@ Solution: Use interceptors to add authentication header automatically.
 // src/lib/api/client.ts
 import { client } from '@/services/sdk/client';
 import { fetchAuthSession } from 'aws-amplify/auth';
+import { getTenantCode as getTenantFromStore } from '@/store/tenant';
 
 // Configure the base URL
 client.setConfig({

--- a/i18n/en/docusaurus-plugin-content-docs/current/frontend-project-structure.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/frontend-project-structure.md
@@ -290,8 +290,10 @@ Example: ProductList container that fetches products, handles loading/error stat
 
 import { useProducts } from '@/hooks/useProducts';
 import { ProductTable } from '@/components/products/ProductTable';
-import { Button } from '@/components/ui/Button';
+import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { ErrorMessage } from '@/components/ui/error-message';
 
 export function ProductList() {
   const router = useRouter();

--- a/i18n/en/docusaurus-plugin-content-docs/current/import.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/import.md
@@ -188,7 +188,7 @@ await this.importService.updateStatus(
 );
 ```
 
-#### `getImportByKey(key: DetailKey): Promise<ImportEntity>`
+#### `getImportByKey(key: DetailKey): Promise<ImportEntity | null>`
 
 Retrieves an import entity by its key.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/api-integration-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/api-integration-patterns.md
@@ -158,6 +158,7 @@ export class ProductService {
 // src/lib/api/client.ts
 import { client } from '@/services/sdk/client';
 import { fetchAuthSession } from 'aws-amplify/auth';
+import { getTenantCode as getTenantFromStore } from '@/store/tenant';
 
 // ベースURLを設定
 client.setConfig({

--- a/i18n/ja/docusaurus-plugin-content-docs/current/frontend-project-structure.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/frontend-project-structure.md
@@ -290,8 +290,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 import { useProducts } from '@/hooks/useProducts';
 import { ProductTable } from '@/components/products/ProductTable';
-import { Button } from '@/components/ui/Button';
+import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { ErrorMessage } from '@/components/ui/error-message';
 
 export function ProductList() {
   const router = useRouter();

--- a/i18n/ja/docusaurus-plugin-content-docs/current/import.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/import.md
@@ -188,7 +188,7 @@ await this.importService.updateStatus(
 );
 ```
 
-#### `getImportByKey(key: DetailKey): Promise<ImportEntity>`
+#### `getImportByKey(key: DetailKey): Promise<ImportEntity | null>`
 
 キーによってインポートエンティティを取得します。
 


### PR DESCRIPTION
## Summary

- **import.md**: Fixed `getImportByKey()` return type from `Promise<ImportEntity>` to `Promise<ImportEntity | null>` — the actual implementation in `import.service.ts` returns `null` when no item is found
- **frontend-project-structure.md**: Added missing `LoadingSpinner` and `ErrorMessage` imports to the `ProductList` container example; also fixed `Button` import path from `ui/Button` to `ui/button` (lowercase, consistent with shadcn/ui convention)
- **api-integration-patterns.md**: Added `import { getTenantCode as getTenantFromStore } from '@/store/tenant'` — the `getTenantFromStore()` function was called in the axios interceptor example but was never imported, making the code fail if copied

## Test plan

- [x] `npm run translate:replace-placeholders` completes successfully
- [x] `npm run build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)