### PR TITLE
fix(docs): correct getUserContext return fields, PK format, and MySQL schema param

### DIFF
--- a/docs/entity-patterns.md
+++ b/docs/entity-patterns.md
@@ -69,7 +69,7 @@ export class ProductDataEntity extends DataEntity {
 
 | {{Property}} | {{Type}} | {{Required}} | {{Description}} |
 |--------------|----------|--------------|-----------------|
-| `pk` | `string` | {{Yes}} | {{Partition key. Format: `{tenantCode}#{entityType}`}} |
+| `pk` | `string` | {{Yes}} | {{Partition key. Format: `{entityType}#{tenantCode}`}} |
 | `sk` | `string` | {{Yes}} | {{Sort key. Format: `{entityType}#{entityId}`}} |
 | `id` | `string` | {{Yes}} | {{Unique entity identifier}} |
 | `code` | `string` | {{Yes}} | {{Business code}} |
@@ -129,7 +129,7 @@ export class ProductCommandEntity extends CommandEntity {
 
 | {{Property}} | {{Type}} | {{Required}} | {{Description}} |
 |--------------|----------|--------------|-----------------|
-| `pk` | `string` | {{Yes}} | {{Partition key. Format: `{tenantCode}#{entityType}`}} |
+| `pk` | `string` | {{Yes}} | {{Partition key. Format: `{entityType}#{tenantCode}`}} |
 | `sk` | `string` | {{Yes}} | {{Sort key. Format: `{entityType}#{entityId}@{version}`}} |
 | `id` | `string` | {{Yes}} | {{Unique entity identifier}} |
 | `code` | `string` | {{Yes}} | {{Business code}} |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -134,7 +134,7 @@ description: {{Learn how to add and validate your environment variables in your 
 
 | {{Variable}} | {{Description}} | {{Required}} | {{Example}} |
 |-------------|-----------------|--------------|-------------|
-| `DATABASE_URL` | {{Database connection URL for Prisma ORM}} | {{No}} | `mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection_limit=1` |
+| `DATABASE_URL` | {{Database connection URL for Prisma ORM}} | {{No}} | `mysql://root:RootCqrs@localhost:3306/cqrs?connection_limit=1` |
 
 ### {{Example .env file}}
 
@@ -204,7 +204,7 @@ SES_REGION=ap-northeast-1
 SES_FROM_EMAIL=email@example.com
 
 # {{Database Configuration}}
-DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection_limit=1"
+DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?connection_limit=1"
 ```
 
 ## {{Validate Environment Variables}}

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -172,13 +172,13 @@ const { bucket, key } = parseS3AttributeKey('s3://my-bucket/path/to/file.pdf');
 
 ### `getUserContext(ctx: IInvoke | ExecutionContext): UserContext`
 
-{{Extracts user context from the invocation context. Returns userId, tenantCode, and tenantRole.}}
+{{Extracts user context from the invocation context. Returns userId, tenantCode, tenantRole, tenantRoles, and tenantGroupIds.}}
 
 ```ts
 import { getUserContext } from '@mbc-cqrs-serverless/core';
 
 const userContext = getUserContext(invokeContext);
-// {{Returns:}} { userId: '...', tenantCode: 'mbc', tenantRole: 'admin' }
+// {{Returns:}} { userId: '...', tenantCode: 'mbc', tenantRole: 'admin', tenantRoles: ['admin'], tenantGroupIds: [] }
 ```
 
 ### `extractInvokeContext(ctx?: ExecutionContext): IInvoke`

--- a/i18n/en/docusaurus-plugin-content-docs/current/entity-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/entity-patterns.md
@@ -69,7 +69,7 @@ The `DataEntity` base class includes:
 
 | Property | Type | Required | Description |
 |--------------|----------|--------------|-----------------|
-| `pk` | `string` | Yes | Partition key. Format: `{tenantCode}#{entityType}` |
+| `pk` | `string` | Yes | Partition key. Format: `{entityType}#{tenantCode}` |
 | `sk` | `string` | Yes | Sort key. Format: `{entityType}#{entityId}` |
 | `id` | `string` | Yes | Unique entity identifier |
 | `code` | `string` | Yes | Business code |
@@ -129,7 +129,7 @@ The `CommandEntity` base class includes:
 
 | Property | Type | Required | Description |
 |--------------|----------|--------------|-----------------|
-| `pk` | `string` | Yes | Partition key. Format: `{tenantCode}#{entityType}` |
+| `pk` | `string` | Yes | Partition key. Format: `{entityType}#{tenantCode}` |
 | `sk` | `string` | Yes | Sort key. Format: `{entityType}#{entityId}@{version}` |
 | `id` | `string` | Yes | Unique entity identifier |
 | `code` | `string` | Yes | Business code |

--- a/i18n/en/docusaurus-plugin-content-docs/current/environment-variables.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/environment-variables.md
@@ -134,7 +134,7 @@ Set `NOTIFICATION_TRANSPORTS=appsync-event` (or `appsync-graphql,appsync-event` 
 
 | Variable | Description | Required | Example |
 |-------------|-----------------|--------------|-------------|
-| `DATABASE_URL` | Database connection URL for Prisma ORM | No | `mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection_limit=1` |
+| `DATABASE_URL` | Database connection URL for Prisma ORM | No | `mysql://root:RootCqrs@localhost:3306/cqrs?connection_limit=1` |
 
 ### Example .env file
 
@@ -204,7 +204,7 @@ SES_REGION=ap-northeast-1
 SES_FROM_EMAIL=email@example.com
 
 # Database Configuration
-DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection_limit=1"
+DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?connection_limit=1"
 ```
 
 ## Validate Environment Variables

--- a/i18n/en/docusaurus-plugin-content-docs/current/helpers.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/helpers.md
@@ -172,13 +172,13 @@ Functions for working with invocation context and user information.
 
 ### `getUserContext(ctx: IInvoke | ExecutionContext): UserContext`
 
-Extracts user context from the invocation context. Returns userId, tenantCode, and tenantRole.
+Extracts user context from the invocation context. Returns userId, tenantCode, tenantRole, tenantRoles, and tenantGroupIds.
 
 ```ts
 import { getUserContext } from '@mbc-cqrs-serverless/core';
 
 const userContext = getUserContext(invokeContext);
-// Returns: { userId: '...', tenantCode: 'mbc', tenantRole: 'admin' }
+// Returns: { userId: '...', tenantCode: 'mbc', tenantRole: 'admin', tenantRoles: ['admin'], tenantGroupIds: [] }
 ```
 
 ### `extractInvokeContext(ctx?: ExecutionContext): IInvoke`

--- a/i18n/en/translation/entity-patterns.json
+++ b/i18n/en/translation/entity-patterns.json
@@ -42,6 +42,7 @@
   "Description": "Description",
   "Yes": "Yes",
   "Partition key. Format: `{tenantCode}#{entityType}`": "Partition key. Format: `{tenantCode}#{entityType}`",
+  "Partition key. Format: `{entityType}#{tenantCode}`": "Partition key. Format: `{entityType}#{tenantCode}`",
   "Sort key. Format: `{entityType}#{entityId}`": "Sort key. Format: `{entityType}#{entityId}`",
   "Unique entity identifier": "Unique entity identifier",
   "Business code": "Business code",

--- a/i18n/en/translation/helpers.json
+++ b/i18n/en/translation/helpers.json
@@ -38,6 +38,7 @@
   "Context Helpers": "Context Helpers",
   "Functions for working with invocation context and user information.": "Functions for working with invocation context and user information.",
   "Extracts user context from the invocation context. Returns userId, tenantCode, and tenantRole.": "Extracts user context from the invocation context. Returns userId, tenantCode, and tenantRole.",
+  "Extracts user context from the invocation context. Returns userId, tenantCode, tenantRole, tenantRoles, and tenantGroupIds.": "Extracts user context from the invocation context. Returns userId, tenantCode, tenantRole, tenantRoles, and tenantGroupIds.",
   "Returns:": "Returns:",
   "Extracts the invocation context from a NestJS execution context. Supports both Lambda and local development environments.": "Extracts the invocation context from a NestJS execution context. Supports both Lambda and local development environments.",
   "Use ctx for further operations": "Use ctx for further operations",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/entity-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/entity-patterns.md
@@ -69,7 +69,7 @@ export class ProductDataEntity extends DataEntity {
 
 | プロパティ | 型 | 必須 | 説明 |
 |--------------|----------|--------------|-----------------|
-| `pk` | `string` | はい | パーティションキー。形式: `{tenantCode}#{entityType}` |
+| `pk` | `string` | はい | パーティションキー。形式: `{entityType}#{tenantCode}` |
 | `sk` | `string` | はい | ソートキー。形式: `{entityType}#{entityId}` |
 | `id` | `string` | はい | エンティティの一意識別子 |
 | `code` | `string` | はい | ビジネスコード |
@@ -129,7 +129,7 @@ export class ProductCommandEntity extends CommandEntity {
 
 | プロパティ | 型 | 必須 | 説明 |
 |--------------|----------|--------------|-----------------|
-| `pk` | `string` | はい | パーティションキー。形式: `{tenantCode}#{entityType}` |
+| `pk` | `string` | はい | パーティションキー。形式: `{entityType}#{tenantCode}` |
 | `sk` | `string` | はい | ソートキー。形式: `{entityType}#{entityId}@{version}` |
 | `id` | `string` | はい | エンティティの一意識別子 |
 | `code` | `string` | はい | ビジネスコード |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/environment-variables.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/environment-variables.md
@@ -134,7 +134,7 @@ MBC CQRS サーバーレスフレームワークには、環境変数を `.env*`
 
 | 変数 | 説明 | 必須 | 例 |
 |-------------|-----------------|--------------|-------------|
-| `DATABASE_URL` | Prisma ORM用のデータベース接続URL | いいえ | `mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection_limit=1` |
+| `DATABASE_URL` | Prisma ORM用のデータベース接続URL | いいえ | `mysql://root:RootCqrs@localhost:3306/cqrs?connection_limit=1` |
 
 ### .env ファイルの例
 
@@ -204,7 +204,7 @@ SES_REGION=ap-northeast-1
 SES_FROM_EMAIL=email@example.com
 
 # データベース設定
-DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?schema=public&connection_limit=1"
+DATABASE_URL="mysql://root:RootCqrs@localhost:3306/cqrs?connection_limit=1"
 ```
 
 ## 環境変数の検証

--- a/i18n/ja/docusaurus-plugin-content-docs/current/helpers.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/helpers.md
@@ -172,13 +172,13 @@ const { bucket, key } = parseS3AttributeKey('s3://my-bucket/path/to/file.pdf');
 
 ### `getUserContext(ctx: IInvoke | ExecutionContext): UserContext`
 
-呼び出しコンテキストからユーザーコンテキストを抽出します。userId、tenantCode、tenantRoleを返します。
+呼び出しコンテキストからユーザーコンテキストを抽出します。userId、tenantCode、tenantRole、tenantRoles、tenantGroupIdsを返します。
 
 ```ts
 import { getUserContext } from '@mbc-cqrs-serverless/core';
 
 const userContext = getUserContext(invokeContext);
-// 戻り値: { userId: '...', tenantCode: 'mbc', tenantRole: 'admin' }
+// 戻り値: { userId: '...', tenantCode: 'mbc', tenantRole: 'admin', tenantRoles: ['admin'], tenantGroupIds: [] }
 ```
 
 ### `extractInvokeContext(ctx?: ExecutionContext): IInvoke`

--- a/i18n/ja/translation/entity-patterns.json
+++ b/i18n/ja/translation/entity-patterns.json
@@ -42,6 +42,7 @@
   "Description": "説明",
   "Yes": "はい",
   "Partition key. Format: `{tenantCode}#{entityType}`": "パーティションキー。形式: `{tenantCode}#{entityType}`",
+  "Partition key. Format: `{entityType}#{tenantCode}`": "パーティションキー。形式: `{entityType}#{tenantCode}`",
   "Sort key. Format: `{entityType}#{entityId}`": "ソートキー。形式: `{entityType}#{entityId}`",
   "Unique entity identifier": "エンティティの一意識別子",
   "Business code": "ビジネスコード",

--- a/i18n/ja/translation/helpers.json
+++ b/i18n/ja/translation/helpers.json
@@ -38,6 +38,7 @@
   "Context Helpers": "コンテキストヘルパー",
   "Functions for working with invocation context and user information.": "呼び出しコンテキストとユーザー情報を操作するための関数。",
   "Extracts user context from the invocation context. Returns userId, tenantCode, and tenantRole.": "呼び出しコンテキストからユーザーコンテキストを抽出します。userId、tenantCode、tenantRoleを返します。",
+  "Extracts user context from the invocation context. Returns userId, tenantCode, tenantRole, tenantRoles, and tenantGroupIds.": "呼び出しコンテキストからユーザーコンテキストを抽出します。userId、tenantCode、tenantRole、tenantRoles、tenantGroupIdsを返します。",
   "Returns:": "戻り値:",
   "Extracts the invocation context from a NestJS execution context. Supports both Lambda and local development environments.": "NestJS実行コンテキストから呼び出しコンテキストを抽出します。Lambdaとローカル開発環境の両方をサポートします。",
   "Use ctx for further operations": "ctxを後続の操作に使用",


### PR DESCRIPTION
## Summary

- **helpers.md**: `getUserContext()` returns 5 fields (`userId`, `tenantCode`, `tenantRole`, `tenantRoles`, `tenantGroupIds`). The description and code comment only showed 3 fields, misleading developers who need `tenantRoles` or `tenantGroupIds` for authorization logic.
- **entity-patterns.md**: PK format description in the `DataEntity` and `CommandEntity` tables was reversed. The correct convention throughout the framework is `{entityType}#{tenantCode}` (e.g., `PRODUCT#tenant001`), not `{tenantCode}#{entityType}`. Consistent with all other doc examples and framework usage.
- **environment-variables.md**: Removed `schema=public` from the MySQL `DATABASE_URL` example (table and .env block). The `schema=` parameter is PostgreSQL-only and has no effect or causes errors with MySQL Prisma connections.

## Test plan

- [x] `npm run translate:replace-placeholders` — completed successfully
- [x] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)