### PR TITLE
fix(docs): add missing #anti-pattern-detection anchor to mcp-server.md

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -144,7 +144,7 @@ npx @mbc-cqrs-serverless/mcp-server
 {{Code analysis tools (`mbc_check_anti_patterns`, `mbc_health_check`, `mbc_explain_code`) were added in [version 1.0.22](/docs/changelog#v1022).}}
 :::
 
-### {{Anti-Pattern Detection}}
+### {{Anti-Pattern Detection}} {#anti-pattern-detection}
 
 :::info {{Version Note}}
 {{AP011–AP015 were added in [v1.2.x](/docs/changelog#v120) (publishSync null check, deprecated APIs, TaskModule duplication). AP016–AP020 were added in [v1.2.5](/docs/changelog#v125). AP021 (event emit after publishAsync) was added in [v1.2.6](/docs/changelog#v126). AP022–AP025 (eval, shell injection, HTTP timeout, sensitive logging) were added in v1.2.7.}}

--- a/i18n/en/docusaurus-plugin-content-docs/current/mcp-server.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/mcp-server.md
@@ -144,7 +144,7 @@ Get help debugging errors.
 Code analysis tools (`mbc_check_anti_patterns`, `mbc_health_check`, `mbc_explain_code`) were added in [version 1.0.22](/docs/changelog#v1022).
 :::
 
-### Anti-Pattern Detection
+### Anti-Pattern Detection {#anti-pattern-detection}
 
 :::info Version Note
 AP011–AP015 were added in [v1.2.x](/docs/changelog#v120) (publishSync null check, deprecated APIs, TaskModule duplication). AP016–AP020 were added in [v1.2.5](/docs/changelog#v125). AP021 (event emit after publishAsync) was added in [v1.2.6](/docs/changelog#v126). AP022–AP025 (eval, shell injection, HTTP timeout, sensitive logging) were added in v1.2.7.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/mcp-server.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/mcp-server.md
@@ -144,7 +144,7 @@ Claude Codeに以下のように依頼できます:
 コード分析ツール（`mbc_check_anti_patterns`、`mbc_health_check`、`mbc_explain_code`）は[バージョン1.0.22](/docs/changelog#v1022)で追加されました。
 :::
 
-### アンチパターン検出
+### アンチパターン検出 {#anti-pattern-detection}
 
 :::info バージョン情報
 AP011〜AP015 は [v1.2.x](/docs/changelog#v120)（publishSync の null チェック、非推奨API、TaskModule 重複）で追加されました。AP016〜AP020 は [v1.2.5](/docs/changelog#v125) で追加。AP021（publishAsync 後のイベント発行）は [v1.2.6](/docs/changelog#v126) で追加。AP022〜AP025（eval、シェルインジェクション、HTTPタイムアウト、機密情報ロギング）は v1.2.7 で追加されました。


### PR DESCRIPTION
## Summary

- `anti-patterns.md` cross-links to `/docs/mcp-server#anti-pattern-detection` but the `### Anti-Pattern Detection` heading in `mcp-server.md` had no explicit anchor ID, causing a build warning on every build: `Broken anchor on source page path = /ja/docs/anti-patterns: -> linking to /ja/docs/mcp-server#anti-pattern-detection`.
- Added `{#anti-pattern-detection}` to the section heading. The build now completes with zero broken anchor warnings.

## Test plan

- [x] `npm run build` — no broken anchor warnings (previously warned on every build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)