### PR TITLE
fix: correct genNewSequence removal version and add findOne null check

### DIFF
--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -293,8 +293,9 @@ export class ProductService {
   /**
    * {{Get product by key}}
    */
-  async findOne(pk: string, sk: string): Promise<ProductDataEntity> {
+  async findOne(pk: string, sk: string): Promise<ProductDataEntity | null> {
     const item = await this.dataService.getItem({ pk, sk });
+    if (!item) return null;
     return new ProductDataEntity(item);
   }
 }

--- a/docs/sequence.md
+++ b/docs/sequence.md
@@ -76,7 +76,7 @@ export class SeqModule {}
 
 {{Beside controller, we can directly use `SequencesService` to generating sequence by injecting service.}}
 
-{{The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):}}
+{{The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.1.0):}}
 
 ### {{*async* `generateSequenceItem( dto: GenerateFormattedSequenceDto, options?: {invokeContext:IInvoke}):  Promise<SequenceEntity>`}} {#generate-sequence-item}
 
@@ -320,9 +320,9 @@ const result = await this.sequencesService.generateSequenceItemWithProvideSettin
 
 ### {{*async* `genNewSequence( dto: GenerateSequenceDto, options: {invokeContext: IInvoke}): Promise<DataEntity>` <span class="badge badge--danger">removed</span>}} {#gen-new-sequence-removed}
 
-:::danger {{Removed in v1.2.0}}
+:::danger {{Removed in v1.1.0}}
 
-{{This method was removed in [v1.2.0](/docs/changelog#v120). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.}}
+{{This method was removed in [v1.1.0](/docs/changelog#v110). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.}}
 
 :::
 

--- a/i18n/en/translation/sequence.json
+++ b/i18n/en/translation/sequence.json
@@ -95,7 +95,9 @@
   "Deprecated, for removal: This API element is subject to removal in a future version.": "Deprecated, for removal: This API element is subject to removal in a future version.",
   "*async* `genNewSequence( dto: GenerateSequenceDto, options: {invokeContext: IInvoke}): Promise<DataEntity>` <span class=\"badge badge--danger\">removed</span>": "*async* `genNewSequence( dto: GenerateSequenceDto, options: {invokeContext: IInvoke}): Promise<DataEntity>` <span class=\"badge badge--danger\">removed</span>",
   "Removed in v1.2.0": "Removed in v1.2.0",
+  "Removed in v1.1.0": "Removed in v1.1.0",
   "This method was removed in [v1.2.0](/docs/changelog#v120). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.": "This method was removed in [v1.2.0](/docs/changelog#v120). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.",
+  "This method was removed in [v1.1.0](/docs/changelog#v110). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.": "This method was removed in [v1.1.0](/docs/changelog#v110). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.",
   "Related Documentation": "Related Documentation",
   "Configuring": "Configuring",
   "SequencesModule configuration options": "SequencesModule configuration options",
@@ -105,5 +107,6 @@
   "Practical example using sequences": "Practical example using sequences",
   "Interfaces": "Interfaces",
   "SequencesModuleOptions interface": "SequencesModuleOptions interface",
-  "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):": "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):"
+  "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):": "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):",
+  "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.1.0):": "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.1.0):"
 }

--- a/i18n/ja/translation/sequence.json
+++ b/i18n/ja/translation/sequence.json
@@ -95,7 +95,9 @@
   "Deprecated, for removal: This API element is subject to removal in a future version.": "非推奨、削除予定: この API 要素は将来のバージョンで削除される可能性があります",
   "*async* `genNewSequence( dto: GenerateSequenceDto, options: {invokeContext: IInvoke}): Promise<DataEntity>` <span class=\"badge badge--danger\">removed</span>": "*async* `genNewSequence( dto: GenerateSequenceDto, options: {invokeContext: IInvoke}): Promise<DataEntity>` <span class=\"badge badge--danger\">削除済み</span>",
   "Removed in v1.2.0": "v1.2.0で削除",
+  "Removed in v1.1.0": "v1.1.0で削除",
   "This method was removed in [v1.2.0](/docs/changelog#v120). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.": "このメソッドは[v1.2.0](/docs/changelog#v120)で削除されました。代わりに[`generateSequenceItem`](#generate-sequence-item)または[`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting)を使用してください。",
+  "This method was removed in [v1.1.0](/docs/changelog#v110). Use [`generateSequenceItem`](#generate-sequence-item) or [`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting) instead.": "このメソッドは[v1.1.0](/docs/changelog#v110)で削除されました。代わりに[`generateSequenceItem`](#generate-sequence-item)または[`generateSequenceItemWithProvideSetting`](#generate-sequence-item-with-provide-setting)を使用してください。",
   "Related Documentation": "関連ドキュメント",
   "Configuring": "設定",
   "SequencesModule configuration options": "SequencesModuleの設定オプション",
@@ -105,5 +107,6 @@
   "Practical example using sequences": "シーケンスを使った実践的な例",
   "Interfaces": "インターフェース",
   "SequencesModuleOptions interface": "SequencesModuleOptionsインターフェース",
-  "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):": "`SequencesService`には4つのパブリックメソッドがあります（現行2つ、非推奨1つ、v1.2.0で削除1つ）："
+  "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.2.0):": "`SequencesService`には4つのパブリックメソッドがあります（現行2つ、非推奨1つ、v1.2.0で削除1つ）：",
+  "The `SequencesService` has four public methods (two current, one deprecated, one removed in v1.1.0):": "`SequencesService`には4つのパブリックメソッドがあります（現行2つ、非推奨1つ、v1.1.0で削除1つ）："
 }


### PR DESCRIPTION
## Summary
- **sequence.md**: `genNewSequence()` was removed in v1.1.0 (not v1.2.0 as previously stated). Updated 3 references on lines 79, 323, and 325, plus corresponding EN/JA translation keys. This matches the v1.1.0 migration guide (Breaking Change 3) which explicitly documents the removal.
- **backend-development.md**: `findOne()` method now correctly returns `Promise<ProductDataEntity | null>` and guards against `null` from `getItem()` before passing to the `ProductDataEntity` constructor.

## Test plan
- [x] `npm run translate:replace-placeholders` — passes
- [x] `npm run build` — passes clean, no broken anchors or warnings