### PR TITLE
fix: remove genNewSequence from v1.2.0 changelog and fix ConditionalCheck mock in unit-test

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -146,9 +146,6 @@ description: {{Track all notable changes, new features, and bug fixes in MBC CQR
   - {{Return type changes from `Promise<CommandModel>` to `Promise<CommandModel | null>`}}
   - {{Matches the existing behavior of `publishAsync()` and `publishPartialUpdateAsync()`}}
   - {{Migration: add a null check before accessing any property on the result}}
-- **sequence:** {{`SequenceService.genNewSequence()` has been removed}} ([{{See Details}}](/docs/sequence#gen-new-sequence-removed)) ([PR #375](https://github.com/mbc-net/mbc-cqrs-serverless/pull/375))
-  - {{Use `generateSequenceItem()` or `generateSequenceItemWithProvideSetting()` instead}}
-
 ### {{Features}}
 
 - **core:** {{Add Read-Your-Writes (RYW) consistency via `SessionService` and `Repository`}} ([{{See Details}}](/docs/command-service#read-your-writes)) ([PR #375](https://github.com/mbc-net/mbc-cqrs-serverless/pull/375))
@@ -872,7 +869,7 @@ description: {{Track all notable changes, new features, and bug fixes in MBC CQR
 ## {{Related Documentation}}
 
 - [{{Migration Guide v1.3.0}}](/docs/migration/v1.3.0) - {{Upgrade guide for v1.3.0 (nodemailer v8)}}
-- [{{Migration Guide v1.2.0}}](/docs/migration/v1.2.0) - {{Upgrade guide for v1.2.0 (publishSync null, genNewSequence removal)}}
+- [{{Migration Guide v1.2.0}}](/docs/migration/v1.2.0) - {{Upgrade guide for v1.2.0 (publishSync null return value)}}
 - [{{Migration Guide v1.1.0}}](/docs/migration/v1.1.0) - {{Upgrade guide for v1.1.0 (TENANT_COMMON, tenant code normalization)}}
 - [{{Version Conflict Guide}}](/docs/version-conflict-guide) - {{Handling version conflicts in upgrades}}
 

--- a/docs/unit-test.md
+++ b/docs/unit-test.md
@@ -260,12 +260,12 @@ dynamoMock.on(GetItemCommand).callsFake((input) => {
 {{Test error handling by making mocks reject:}}
 
 ```ts
-it('should handle DynamoDB errors gracefully', async () => {
-  dynamoMock.on(PutItemCommand).rejects(
-    new Error('ConditionalCheckFailedException')
-  )
+it('should handle ConditionalCheckFailedException as 409 conflict', async () => {
+  const error = new Error('The conditional request failed')
+  error.name = 'ConditionalCheckFailedException'
+  dynamoMock.on(PutItemCommand).rejects(error)
 
-  await expect(myService.saveItem(data)).rejects.toThrow('ConditionalCheckFailedException')
+  await expect(myService.saveItem(data)).rejects.toThrow(ConflictException)
 })
 ```
 

--- a/i18n/en/translation/changelog.json
+++ b/i18n/en/translation/changelog.json
@@ -371,6 +371,7 @@
   "Upgrade guide for v1.3.0 (nodemailer v8)": "Upgrade guide for v1.3.0 (nodemailer v8)",
   "Migration Guide v1.2.0": "Migration Guide v1.2.0",
   "Upgrade guide for v1.2.0 (publishSync null, genNewSequence removal)": "Upgrade guide for v1.2.0 (publishSync null, genNewSequence removal)",
+  "Upgrade guide for v1.2.0 (publishSync null return value)": "Upgrade guide for v1.2.0 (publishSync null return value)",
   "Migration Guide v1.1.0": "Migration Guide v1.1.0",
   "Upgrade guide for v1.1.0 (TENANT_COMMON, tenant code normalization)": "Upgrade guide for v1.1.0 (TENANT_COMMON, tenant code normalization)",
   "Version Conflict Guide": "Version Conflict Guide",

--- a/i18n/ja/translation/changelog.json
+++ b/i18n/ja/translation/changelog.json
@@ -371,6 +371,7 @@
   "Upgrade guide for v1.3.0 (nodemailer v8)": "v1.3.0アップグレードガイド（nodemailer v8）",
   "Migration Guide v1.2.0": "マイグレーションガイド v1.2.0",
   "Upgrade guide for v1.2.0 (publishSync null, genNewSequence removal)": "v1.2.0アップグレードガイド（publishSyncのnull返却、genNewSequenceの削除）",
+  "Upgrade guide for v1.2.0 (publishSync null return value)": "v1.2.0アップグレードガイド（publishSyncのnull返却）",
   "Migration Guide v1.1.0": "マイグレーションガイド v1.1.0",
   "Upgrade guide for v1.1.0 (TENANT_COMMON, tenant code normalization)": "v1.1.0アップグレードガイド（TENANT_COMMON、テナントコードの正規化）",
   "Version Conflict Guide": "バージョン競合ガイド",


### PR DESCRIPTION
## Summary
- **changelog.md**: `genNewSequence()` was already removed in v1.1.0 (per v1.1.0 migration guide Breaking Change 3). Remove the duplicate entry from v1.2.0 breaking changes section and update the v1.2.0 migration guide description to drop the reference.
- **unit-test.md**: The previous mock pattern `new Error('ConditionalCheckFailedException')` sets `error.message` but not `error.name`. The framework catches this error via `error.name === 'ConditionalCheckFailedException'` (error-catalog.md) and `instanceof ConditionalCheckFailedException` (recipes.md), so the old mock would not trigger the correct catch handler. Fixed to `error.name = 'ConditionalCheckFailedException'` with an assertion on `ConflictException`.

## Test plan
- [x] `npm run translate:replace-placeholders` — passes
- [x] `npm run build` — passes clean