### PR TITLE
fix(docs): add build step to quickstart, fix error catch pattern and interface types

### DIFF
--- a/docs/multi-tenant-patterns.md
+++ b/docs/multi-tenant-patterns.md
@@ -226,10 +226,13 @@ async function getEmailTemplates() {
 export interface UserTenantAssociation {
   pk: string;           // USER_TENANT#common
   sk: string;           // {tenantCode}#{userCode}
-  tenantCode: string;
-  userCode: string;
-  role: string;         // Role within this tenant
-  isDefault: boolean;   // Default tenant for user
+  tenantCode: string;   // Owner tenant (COMMON_TENANT)
+  attributes: {
+    userCode: string;
+    tenantCode: string; // Associated tenant code
+    role: string;       // Role within this tenant
+    isDefault: boolean; // Default tenant for user
+  };
 }
 
 // user/user.service.ts

--- a/docs/quickstart-tutorial.md
+++ b/docs/quickstart-tutorial.md
@@ -47,6 +47,12 @@ my-app/
 npm install
 ```
 
+{{Build the TypeScript application (required before starting the server):}}
+
+```bash
+npm run build
+```
+
 ## {{Step 3: Start Local Infrastructure}}
 
 {{Start the local development environment using Docker Compose:}}

--- a/docs/version-conflict-guide.md
+++ b/docs/version-conflict-guide.md
@@ -152,7 +152,7 @@ async function updateWithRetry(
   updateData: Partial<CommandInputModel>,
   invokeContext: IInvoke,
   maxRetries = 3,
-): Promise<CommandModel> {
+): Promise<CommandModel | null> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       // {{Get latest version}}
@@ -166,12 +166,12 @@ async function updateWithRetry(
       };
 
       return await commandService.publishPartialUpdateAsync(command, {
-        source: 'updateWithRetry',
         invokeContext,
       });
     } catch (error) {
       if (
         error instanceof ConditionalCheckFailedException ||
+        error.name === 'ConditionalCheckFailedException' ||
         error.statusCode === 409
       ) {
         if (attempt === maxRetries) {

--- a/i18n/en/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
@@ -226,10 +226,13 @@ Handle users belonging to multiple tenants:
 export interface UserTenantAssociation {
   pk: string;           // USER_TENANT#common
   sk: string;           // {tenantCode}#{userCode}
-  tenantCode: string;
-  userCode: string;
-  role: string;         // Role within this tenant
-  isDefault: boolean;   // Default tenant for user
+  tenantCode: string;   // Owner tenant (COMMON_TENANT)
+  attributes: {
+    userCode: string;
+    tenantCode: string; // Associated tenant code
+    role: string;       // Role within this tenant
+    isDefault: boolean; // Default tenant for user
+  };
 }
 
 // user/user.service.ts

--- a/i18n/en/docusaurus-plugin-content-docs/current/quickstart-tutorial.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/quickstart-tutorial.md
@@ -47,6 +47,12 @@ my-app/
 npm install
 ```
 
+Build the TypeScript application (required before starting the server):
+
+```bash
+npm run build
+```
+
 ## Step 3: Start Local Infrastructure
 
 Start the local development environment using Docker Compose:

--- a/i18n/en/docusaurus-plugin-content-docs/current/version-conflict-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/version-conflict-guide.md
@@ -152,7 +152,7 @@ async function updateWithRetry(
   updateData: Partial<CommandInputModel>,
   invokeContext: IInvoke,
   maxRetries = 3,
-): Promise<CommandModel> {
+): Promise<CommandModel | null> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       // Get latest version
@@ -166,12 +166,12 @@ async function updateWithRetry(
       };
 
       return await commandService.publishPartialUpdateAsync(command, {
-        source: 'updateWithRetry',
         invokeContext,
       });
     } catch (error) {
       if (
         error instanceof ConditionalCheckFailedException ||
+        error.name === 'ConditionalCheckFailedException' ||
         error.statusCode === 409
       ) {
         if (attempt === maxRetries) {

--- a/i18n/en/translation/quickstart-tutorial.json
+++ b/i18n/en/translation/quickstart-tutorial.json
@@ -12,6 +12,7 @@
   "Use the MBC CQRS CLI to scaffold a new project:": "Use the MBC CQRS CLI to scaffold a new project:",
   "The CLI will create a project with the following structure:": "The CLI will create a project with the following structure:",
   "Step 2: Install Dependencies": "Step 2: Install Dependencies",
+  "Build the TypeScript application (required before starting the server):": "Build the TypeScript application (required before starting the server):",
   "Step 3: Start Local Infrastructure": "Step 3: Start Local Infrastructure",
   "Start the local development environment using Docker Compose:": "Start the local development environment using Docker Compose:",
   "This starts the following services:": "This starts the following services:",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/multi-tenant-patterns.md
@@ -226,10 +226,13 @@ async function getEmailTemplates() {
 export interface UserTenantAssociation {
   pk: string;           // USER_TENANT#common
   sk: string;           // {tenantCode}#{userCode}
-  tenantCode: string;
-  userCode: string;
-  role: string;         // Role within this tenant
-  isDefault: boolean;   // Default tenant for user
+  tenantCode: string;   // Owner tenant (COMMON_TENANT)
+  attributes: {
+    userCode: string;
+    tenantCode: string; // Associated tenant code
+    role: string;       // Role within this tenant
+    isDefault: boolean; // Default tenant for user
+  };
 }
 
 // user/user.service.ts

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quickstart-tutorial.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quickstart-tutorial.md
@@ -47,6 +47,12 @@ my-app/
 npm install
 ```
 
+TypeScriptアプリケーションをビルドします（サーバー起動前に必要）：
+
+```bash
+npm run build
+```
+
 ## ステップ3: ローカルインフラの起動
 
 Docker Composeを使用してローカル開発環境を起動します：

--- a/i18n/ja/docusaurus-plugin-content-docs/current/version-conflict-guide.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/version-conflict-guide.md
@@ -152,7 +152,7 @@ async function updateWithRetry(
   updateData: Partial<CommandInputModel>,
   invokeContext: IInvoke,
   maxRetries = 3,
-): Promise<CommandModel> {
+): Promise<CommandModel | null> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       // 最新バージョンを取得
@@ -166,12 +166,12 @@ async function updateWithRetry(
       };
 
       return await commandService.publishPartialUpdateAsync(command, {
-        source: 'updateWithRetry',
         invokeContext,
       });
     } catch (error) {
       if (
         error instanceof ConditionalCheckFailedException ||
+        error.name === 'ConditionalCheckFailedException' ||
         error.statusCode === 409
       ) {
         if (attempt === maxRetries) {

--- a/i18n/ja/translation/quickstart-tutorial.json
+++ b/i18n/ja/translation/quickstart-tutorial.json
@@ -12,6 +12,7 @@
   "Use the MBC CQRS CLI to scaffold a new project:": "MBC CQRS CLIを使用して新しいプロジェクトをスキャフォールドします：",
   "The CLI will create a project with the following structure:": "CLIは以下の構造でプロジェクトを作成します：",
   "Step 2: Install Dependencies": "ステップ2: 依存関係のインストール",
+  "Build the TypeScript application (required before starting the server):": "TypeScriptアプリケーションをビルドします（サーバー起動前に必要）：",
   "Step 3: Start Local Infrastructure": "ステップ3: ローカルインフラの起動",
   "Start the local development environment using Docker Compose:": "Docker Composeを使用してローカル開発環境を起動します：",
   "This starts the following services:": "以下のサービスが起動します：",


### PR DESCRIPTION
## Summary

- **quickstart-tutorial.md**: Add missing `npm run build` step after `npm install`. The Serverless Offline config references `../dist/main.handler`, which requires compiled TypeScript output — without this step, `npm run offline:sls` fails immediately with a missing handler error.
- **version-conflict-guide.md**: Add `error.name === 'ConditionalCheckFailedException'` alongside the existing `instanceof` check (both patterns are valid and documented in the framework), and fix `updateWithRetry` return type from `Promise<CommandModel>` to `Promise<CommandModel | null>` since `publishPartialUpdateAsync` can return `null`.
- **multi-tenant-patterns.md**: Fix `UserTenantAssociation` interface — `userCode`, `tenantCode`, `role`, `isDefault` are stored under the nested `attributes` field (matching the `publishSync` call), not as top-level properties. This fixes the interface to match actual runtime data and the existing `a.attributes.tenantCode` access in `switchTenant()`.

## Test plan

- [x] `npm run translate:replace-placeholders` ran cleanly
- [x] `npm run build` passes with no errors