### PR TITLE
fix(docs): correct RolesGuard API signatures, add VERSION_FIRST, fix AWS SDK v3 patterns

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -199,12 +199,6 @@ import { getUserContext } from "./user.context";
 
 @Injectable()
 export class CustomRoleGuard extends RolesGuard {
-  protected async getUserRole(context: ExecutionContext): Promise<string> {
-    const userContext = getUserContext(context);
-
-    return userContext.tenantRole;
-  }
-
   protected async verifyTenant(context: ExecutionContext): Promise<boolean> {
     const userContext = getUserContext(context);
 
@@ -282,7 +276,7 @@ export class AppGroupRoleResolver implements IGroupRoleResolver {
 
 | {{Method}} | {{Description}} | {{Default Behavior}} |
 |------------|-----------------|----------------------|
-| `isHeaderOverride()` | {{Detect if tenant code comes from header}} | {{Returns true if x-tenant-code header differs from Cognito custom:tenant}} |
+| `isHeaderOverride()` | {{Detect if tenant code comes from header}} | {{Returns true when `custom:tenant` is absent from the JWT and a tenant code is present}} |
 | `canOverrideTenant()` | {{Check if user can override tenant}} | {{Returns true for system_admin role}} |
 | `getCommonTenantCodes()` | {{Get list of common tenant codes}} | {{Returns common or value from COMMON_TENANT_CODES env var}} |
 | `getCrossTenantRoles()` | {{Get roles that can access cross-tenant}} | {{Returns system_admin or value from CROSS_TENANT_ROLES env var}} |
@@ -293,8 +287,7 @@ export class AppGroupRoleResolver implements IGroupRoleResolver {
 
 ```ts
 // {{Default behavior in RolesGuard}}
-protected canOverrideTenant(context: ExecutionContext): boolean {
-  const userContext = getUserContext(context);
+protected canOverrideTenant(context: ExecutionContext, userContext: UserContext): boolean {
   const crossTenantRoles = this.getCrossTenantRoles();
   return crossTenantRoles.includes(userContext.tenantRole);
 }
@@ -337,16 +330,14 @@ export class CustomRolesGuard extends RolesGuard {
   }
 
   // {{Custom logic for tenant override permission}}
-  protected canOverrideTenant(context: ExecutionContext): boolean {
-    const userContext = getUserContext(context);
-
+  protected canOverrideTenant(context: ExecutionContext, userContext: UserContext): boolean {
     // {{Allow specific users to override tenant}}
     if (userContext.tenantRole === 'regional_manager') {
       // {{Regional managers can only access tenants in their region}}
       return this.isRegionalManagerForTenant(userContext, context);
     }
 
-    return super.canOverrideTenant(context);
+    return super.canOverrideTenant(context, userContext);
   }
 
   private isRegionalManagerForTenant(userContext: UserContext, context: ExecutionContext): boolean {

--- a/docs/ecommerce-example.md
+++ b/docs/ecommerce-example.md
@@ -114,6 +114,7 @@ import {
   DataService,
   IInvoke,
   KEY_SEPARATOR,
+  VERSION_FIRST,
   getUserContext,
 } from '@mbc-cqrs-serverless/core';
 import { SequencesService } from '@mbc-cqrs-serverless/sequence';
@@ -153,6 +154,7 @@ export class OrderService {
     const command = {
       pk: generatePk(tenantCode),
       sk: `ORDER#${orderCode}`,
+      version: VERSION_FIRST,
       code: orderCode,
       name: `Order ${orderCode}`,
       tenantCode,
@@ -540,7 +542,7 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
 // {{Response}}
 {
   "pk": "TENANT#shop-a",
-  "sk": "ORDER#ORD-000001",
+  "sk": "ORDER#ORD-000001@1",
   "code": "ORD-000001",
   "name": "Order ORD-000001",
   "version": 1,

--- a/docs/error-catalog.md
+++ b/docs/error-catalog.md
@@ -593,23 +593,27 @@ async function processInChunks(items, chunkSize = 100) {
 
 **{{Solution}}**:
 ```typescript
+import { SFNClient, SendTaskSuccessCommand, SendTaskFailureCommand } from '@aws-sdk/client-sfn';
+
+const sfnClient = new SFNClient({});
+
 // {{Proper error handling with Step Functions}}
 export async function handler(event: StepFunctionEvent) {
   try {
     const result = await processTask(event.input);
 
     // {{Send success callback}}
-    await sfn.sendTaskSuccess({
+    await sfnClient.send(new SendTaskSuccessCommand({
       taskToken: event.taskToken,
       output: JSON.stringify(result),
-    }).promise();
+    }));
   } catch (error) {
     // {{Send failure callback}}
-    await sfn.sendTaskFailure({
+    await sfnClient.send(new SendTaskFailureCommand({
       taskToken: event.taskToken,
       error: error.name,
       cause: error.message,
-    }).promise();
+    }));
   }
 }
 ```
@@ -626,12 +630,16 @@ export async function handler(event: StepFunctionEvent) {
 
 **{{Solution}}**:
 ```typescript
+import { S3Client, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+
+const s3Client = new S3Client({});
+
 // {{Check if object exists before downloading}}
 try {
-  await s3.headObject({ Bucket: bucket, Key: key }).promise();
-  const data = await s3.getObject({ Bucket: bucket, Key: key }).promise();
+  await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+  const data = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
 } catch (error) {
-  if (error.code === 'NoSuchKey' || error.code === 'NotFound') {
+  if (error.name === 'NoSuchKey' || error.name === 'NotFound') {
     console.log('File does not exist:', key);
     return null;
   }

--- a/i18n/en/docusaurus-plugin-content-docs/current/authentication.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/authentication.md
@@ -199,12 +199,6 @@ import { getUserContext } from "./user.context";
 
 @Injectable()
 export class CustomRoleGuard extends RolesGuard {
-  protected async getUserRole(context: ExecutionContext): Promise<string> {
-    const userContext = getUserContext(context);
-
-    return userContext.tenantRole;
-  }
-
   protected async verifyTenant(context: ExecutionContext): Promise<boolean> {
     const userContext = getUserContext(context);
 
@@ -282,7 +276,7 @@ The following protected methods can be overridden to customize tenant verificati
 
 | Method | Description | Default Behavior |
 |------------|-----------------|----------------------|
-| `isHeaderOverride()` | Detect if tenant code comes from header | Returns true if x-tenant-code header differs from Cognito custom:tenant |
+| `isHeaderOverride()` | Detect if tenant code comes from header | Returns true when `custom:tenant` is absent from the JWT and a tenant code is present |
 | `canOverrideTenant()` | Check if user can override tenant | Returns true for system_admin role |
 | `getCommonTenantCodes()` | Get list of common tenant codes | Returns common or value from COMMON_TENANT_CODES env var |
 | `getCrossTenantRoles()` | Get roles that can access cross-tenant | Returns system_admin or value from CROSS_TENANT_ROLES env var |
@@ -293,8 +287,7 @@ By default, only users with the `system_admin` role can override the tenant code
 
 ```ts
 // Default behavior in RolesGuard
-protected canOverrideTenant(context: ExecutionContext): boolean {
-  const userContext = getUserContext(context);
+protected canOverrideTenant(context: ExecutionContext, userContext: UserContext): boolean {
   const crossTenantRoles = this.getCrossTenantRoles();
   return crossTenantRoles.includes(userContext.tenantRole);
 }
@@ -337,16 +330,14 @@ export class CustomRolesGuard extends RolesGuard {
   }
 
   // Custom logic for tenant override permission
-  protected canOverrideTenant(context: ExecutionContext): boolean {
-    const userContext = getUserContext(context);
-
+  protected canOverrideTenant(context: ExecutionContext, userContext: UserContext): boolean {
     // Allow specific users to override tenant
     if (userContext.tenantRole === 'regional_manager') {
       // Regional managers can only access tenants in their region
       return this.isRegionalManagerForTenant(userContext, context);
     }
 
-    return super.canOverrideTenant(context);
+    return super.canOverrideTenant(context, userContext);
   }
 
   private isRegionalManagerForTenant(userContext: UserContext, context: ExecutionContext): boolean {

--- a/i18n/en/docusaurus-plugin-content-docs/current/ecommerce-example.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ecommerce-example.md
@@ -114,6 +114,7 @@ import {
   DataService,
   IInvoke,
   KEY_SEPARATOR,
+  VERSION_FIRST,
   getUserContext,
 } from '@mbc-cqrs-serverless/core';
 import { SequencesService } from '@mbc-cqrs-serverless/sequence';
@@ -153,6 +154,7 @@ export class OrderService {
     const command = {
       pk: generatePk(tenantCode),
       sk: `ORDER#${orderCode}`,
+      version: VERSION_FIRST,
       code: orderCode,
       name: `Order ${orderCode}`,
       tenantCode,
@@ -540,7 +542,7 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
 // Response
 {
   "pk": "TENANT#shop-a",
-  "sk": "ORDER#ORD-000001",
+  "sk": "ORDER#ORD-000001@1",
   "code": "ORD-000001",
   "name": "Order ORD-000001",
   "version": 1,

--- a/i18n/en/docusaurus-plugin-content-docs/current/error-catalog.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/error-catalog.md
@@ -593,23 +593,27 @@ async function processInChunks(items, chunkSize = 100) {
 
 **Solution**:
 ```typescript
+import { SFNClient, SendTaskSuccessCommand, SendTaskFailureCommand } from '@aws-sdk/client-sfn';
+
+const sfnClient = new SFNClient({});
+
 // Proper error handling with Step Functions
 export async function handler(event: StepFunctionEvent) {
   try {
     const result = await processTask(event.input);
 
     // Send success callback
-    await sfn.sendTaskSuccess({
+    await sfnClient.send(new SendTaskSuccessCommand({
       taskToken: event.taskToken,
       output: JSON.stringify(result),
-    }).promise();
+    }));
   } catch (error) {
     // Send failure callback
-    await sfn.sendTaskFailure({
+    await sfnClient.send(new SendTaskFailureCommand({
       taskToken: event.taskToken,
       error: error.name,
       cause: error.message,
-    }).promise();
+    }));
   }
 }
 ```
@@ -626,12 +630,16 @@ export async function handler(event: StepFunctionEvent) {
 
 **Solution**:
 ```typescript
+import { S3Client, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+
+const s3Client = new S3Client({});
+
 // Check if object exists before downloading
 try {
-  await s3.headObject({ Bucket: bucket, Key: key }).promise();
-  const data = await s3.getObject({ Bucket: bucket, Key: key }).promise();
+  await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+  const data = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
 } catch (error) {
-  if (error.code === 'NoSuchKey' || error.code === 'NotFound') {
+  if (error.name === 'NoSuchKey' || error.name === 'NotFound') {
     console.log('File does not exist:', key);
     return null;
   }

--- a/i18n/en/translation/authentication.json
+++ b/i18n/en/translation/authentication.json
@@ -42,7 +42,7 @@
   "Description": "Description",
   "Default Behavior": "Default Behavior",
   "Detect if tenant code comes from header": "Detect if tenant code comes from header",
-  "Returns true if x-tenant-code header differs from Cognito custom:tenant": "Returns true if x-tenant-code header differs from Cognito custom:tenant",
+  "Returns true when `custom:tenant` is absent from the JWT and a tenant code is present": "Returns true when `custom:tenant` is absent from the JWT and a tenant code is present",
   "Check if user can override tenant": "Check if user can override tenant",
   "Returns true for system_admin role": "Returns true for system_admin role",
   "Get list of common tenant codes": "Get list of common tenant codes",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/authentication.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/authentication.md
@@ -199,12 +199,6 @@ import { getUserContext } from "./user.context";
 
 @Injectable()
 export class CustomRoleGuard extends RolesGuard {
-  protected async getUserRole(context: ExecutionContext): Promise<string> {
-    const userContext = getUserContext(context);
-
-    return userContext.tenantRole;
-  }
-
   protected async verifyTenant(context: ExecutionContext): Promise<boolean> {
     const userContext = getUserContext(context);
 
@@ -282,7 +276,7 @@ export class AppGroupRoleResolver implements IGroupRoleResolver {
 
 | メソッド | 説明 | デフォルト動作 |
 |------------|-----------------|----------------------|
-| `isHeaderOverride()` | テナントコードがヘッダーからのものかを検出 | x-tenant-codeヘッダーがCognitoのcustom:tenantと異なる場合trueを返す |
+| `isHeaderOverride()` | テナントコードがヘッダーからのものかを検出 | JWTに`custom:tenant`クレームが存在せず、テナントコードが指定されている場合にtrueを返す |
 | `canOverrideTenant()` | ユーザーがテナントをオーバーライドできるかチェック | system_adminロールの場合trueを返す |
 | `getCommonTenantCodes()` | 共通テナントコードのリストを取得 | commonまたはCOMMON_TENANT_CODES環境変数の値を返す |
 | `getCrossTenantRoles()` | クロステナントアクセス可能なロールを取得 | system_adminまたはCROSS_TENANT_ROLES環境変数の値を返す |
@@ -293,8 +287,7 @@ export class AppGroupRoleResolver implements IGroupRoleResolver {
 
 ```ts
 // Default behavior in RolesGuard (RolesGuardのデフォルト動作)
-protected canOverrideTenant(context: ExecutionContext): boolean {
-  const userContext = getUserContext(context);
+protected canOverrideTenant(context: ExecutionContext, userContext: UserContext): boolean {
   const crossTenantRoles = this.getCrossTenantRoles();
   return crossTenantRoles.includes(userContext.tenantRole);
 }
@@ -337,16 +330,14 @@ export class CustomRolesGuard extends RolesGuard {
   }
 
   // Custom logic for tenant override permission (テナントオーバーライド権限のカスタムロジック)
-  protected canOverrideTenant(context: ExecutionContext): boolean {
-    const userContext = getUserContext(context);
-
+  protected canOverrideTenant(context: ExecutionContext, userContext: UserContext): boolean {
     // Allow specific users to override tenant (特定ユーザーにテナントオーバーライドを許可)
     if (userContext.tenantRole === 'regional_manager') {
       // Regional managers can only access tenants in their region (リージョナルマネージャーは自リージョンのテナントのみアクセス可能)
       return this.isRegionalManagerForTenant(userContext, context);
     }
 
-    return super.canOverrideTenant(context);
+    return super.canOverrideTenant(context, userContext);
   }
 
   private isRegionalManagerForTenant(userContext: UserContext, context: ExecutionContext): boolean {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ecommerce-example.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ecommerce-example.md
@@ -114,6 +114,7 @@ import {
   DataService,
   IInvoke,
   KEY_SEPARATOR,
+  VERSION_FIRST,
   getUserContext,
 } from '@mbc-cqrs-serverless/core';
 import { SequencesService } from '@mbc-cqrs-serverless/sequence';
@@ -153,6 +154,7 @@ export class OrderService {
     const command = {
       pk: generatePk(tenantCode),
       sk: `ORDER#${orderCode}`,
+      version: VERSION_FIRST,
       code: orderCode,
       name: `Order ${orderCode}`,
       tenantCode,
@@ -540,7 +542,7 @@ export class OrderDataSyncHandler implements IDataSyncHandler {
 // レスポンス
 {
   "pk": "TENANT#shop-a",
-  "sk": "ORDER#ORD-000001",
+  "sk": "ORDER#ORD-000001@1",
   "code": "ORD-000001",
   "name": "Order ORD-000001",
   "version": 1,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/error-catalog.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/error-catalog.md
@@ -593,23 +593,27 @@ async function processInChunks(items, chunkSize = 100) {
 
 **解決策**:
 ```typescript
+import { SFNClient, SendTaskSuccessCommand, SendTaskFailureCommand } from '@aws-sdk/client-sfn';
+
+const sfnClient = new SFNClient({});
+
 // Step Functionsを使った適切なエラー処理
 export async function handler(event: StepFunctionEvent) {
   try {
     const result = await processTask(event.input);
 
     // 成功コールバックを送信
-    await sfn.sendTaskSuccess({
+    await sfnClient.send(new SendTaskSuccessCommand({
       taskToken: event.taskToken,
       output: JSON.stringify(result),
-    }).promise();
+    }));
   } catch (error) {
     // 失敗コールバックを送信
-    await sfn.sendTaskFailure({
+    await sfnClient.send(new SendTaskFailureCommand({
       taskToken: event.taskToken,
       error: error.name,
       cause: error.message,
-    }).promise();
+    }));
   }
 }
 ```
@@ -626,12 +630,16 @@ export async function handler(event: StepFunctionEvent) {
 
 **解決策**:
 ```typescript
+import { S3Client, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+
+const s3Client = new S3Client({});
+
 // ダウンロード前にオブジェクトが存在するか確認
 try {
-  await s3.headObject({ Bucket: bucket, Key: key }).promise();
-  const data = await s3.getObject({ Bucket: bucket, Key: key }).promise();
+  await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+  const data = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
 } catch (error) {
-  if (error.code === 'NoSuchKey' || error.code === 'NotFound') {
+  if (error.name === 'NoSuchKey' || error.name === 'NotFound') {
     console.log('File does not exist:', key);
     return null;
   }

--- a/i18n/ja/translation/authentication.json
+++ b/i18n/ja/translation/authentication.json
@@ -42,7 +42,7 @@
   "Description": "説明",
   "Default Behavior": "デフォルト動作",
   "Detect if tenant code comes from header": "テナントコードがヘッダーからのものかを検出",
-  "Returns true if x-tenant-code header differs from Cognito custom:tenant": "x-tenant-codeヘッダーがCognitoのcustom:tenantと異なる場合trueを返す",
+  "Returns true when `custom:tenant` is absent from the JWT and a tenant code is present": "JWTに`custom:tenant`クレームが存在せず、テナントコードが指定されている場合にtrueを返す",
   "Check if user can override tenant": "ユーザーがテナントをオーバーライドできるかチェック",
   "Returns true for system_admin role": "system_adminロールの場合trueを返す",
   "Get list of common tenant codes": "共通テナントコードのリストを取得",


### PR DESCRIPTION
## Summary

**authentication.md**
- Fix `canOverrideTenant()` method signature — the real signature is `(context, userContext: UserContext)` with two parameters; the doc had only one (verified against `roles.guard.ts:87-90`)
- Remove deprecated `getUserRole()` override from `CustomRoleGuard` example — `getUserRole` is `@deprecated` and explicitly documented as "Not invoked by verifyRole"; overriding it produces dead code
- Fix `isHeaderOverride()` table description — it returns true when `custom:tenant` is **absent** from the JWT, not when it differs from the header value (verified against `roles.guard.ts:77`)
- Fix `super.canOverrideTenant(context)` → `super.canOverrideTenant(context, userContext)` (missing required arg)

**ecommerce-example.md**
- Add missing `version: VERSION_FIRST` to `createOrder` command — new entities require `version: 0`
- Fix response example `sk` from `ORDER#ORD-000001` to `ORDER#ORD-000001@1` — `publishAsync` returns a `CommandModel` from the COMMAND table where SK carries the `@{version}` suffix

**error-catalog.md**
- Replace AWS SDK v2 `.promise()` chaining with SDK v3 `client.send(new Command())` for SFN (`SendTaskSuccessCommand`, `SendTaskFailureCommand`) and S3 (`HeadObjectCommand`, `GetObjectCommand`)
- Fix `error.code === 'NoSuchKey'` → `error.name === 'NoSuchKey'` (SDK v3 uses `error.name`)

## Test plan

- [x] `npm run translate:replace-placeholders` ran cleanly
- [x] `npm run build` passes with no errors