### PR TITLE
fix(docs): correct DataService.getItem return type and security example

### DIFF
--- a/docs/data-service.md
+++ b/docs/data-service.md
@@ -21,7 +21,7 @@ graph LR
 
 ## {{Methods}}
 
-### {{*async* `getItem(key: DetailKey): Promise<DataModel>`}}
+### {{*async* `getItem(key: DetailKey): Promise<DataModel | undefined>`}}
 
 {{The `getItem` method returns a set of attributes for the item with the given detail/primary key. If there is no matching item, `getItem` returns `undefined`.}}
 

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -285,8 +285,10 @@ async function getOrdersByTenant(invokeContext: IInvoke) {
 async function updateOrder(
   orderId: string,
   updates: UpdateOrderDto,
-  userId: string,
-): Promise<Order> {
+  invokeContext: IInvoke,
+): Promise<CommandModel | null> {
+  // {{Derive user identity from verified JWT — never from request parameters}}
+  const { userId } = getUserContext(invokeContext);
   const order = await this.dataService.getItem({ pk, sk });
 
   if (!order) {
@@ -303,7 +305,7 @@ async function updateOrder(
     sk: order.sk,
     version: order.version,
     ...updates,
-  }, options);
+  }, { invokeContext });
 }
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/data-service.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/data-service.md
@@ -21,7 +21,7 @@ Before using the DataService, you need to set up the CommandModule as described 
 
 ## Methods
 
-### *async* `getItem(key: DetailKey): Promise<DataModel>`
+### *async* `getItem(key: DetailKey): Promise<DataModel | undefined>`
 
 The `getItem` method returns a set of attributes for the item with the given detail/primary key. If there is no matching item, `getItem` returns `undefined`.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/security-best-practices.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/security-best-practices.md
@@ -285,8 +285,10 @@ Check ownership before allowing operations.
 async function updateOrder(
   orderId: string,
   updates: UpdateOrderDto,
-  userId: string,
-): Promise<Order> {
+  invokeContext: IInvoke,
+): Promise<CommandModel | null> {
+  // Derive user identity from verified JWT — never from request parameters
+  const { userId } = getUserContext(invokeContext);
   const order = await this.dataService.getItem({ pk, sk });
 
   if (!order) {
@@ -303,7 +305,7 @@ async function updateOrder(
     sk: order.sk,
     version: order.version,
     ...updates,
-  }, options);
+  }, { invokeContext });
 }
 ```
 

--- a/i18n/en/translation/data-service.json
+++ b/i18n/en/translation/data-service.json
@@ -9,7 +9,7 @@
   "Query Results": "Query Results",
   "Before using the DataService, you need to set up the CommandModule as described in [the CommandService section](/docs/command-service).": "Before using the DataService, you need to set up the CommandModule as described in [the CommandService section](/docs/command-service).",
   "Methods": "Methods",
-  "*async* `getItem(key: DetailKey): Promise<DataModel>`": "*async* `getItem(key: DetailKey): Promise<DataModel>`",
+  "*async* `getItem(key: DetailKey): Promise<DataModel | undefined>`": "*async* `getItem(key: DetailKey): Promise<DataModel | undefined>`",
   "The `getItem` method returns a set of attributes for the item with the given detail/primary key. If there is no matching item, `getItem` returns `undefined`.": "The `getItem` method returns a set of attributes for the item with the given detail/primary key. If there is no matching item, `getItem` returns `undefined`.",
   "Example:": "Example:",
   "*async* `listItemsByPk(pk: string, opts?: ListItemsOptions): Promise<DataListEntity>`": "*async* `listItemsByPk(pk: string, opts?: ListItemsOptions): Promise<DataListEntity>`",

--- a/i18n/en/translation/security-best-practices.json
+++ b/i18n/en/translation/security-best-practices.json
@@ -37,6 +37,7 @@
   "Tenant is always part of the partition key": "Tenant is always part of the partition key",
   "Resource-Level Authorization": "Resource-Level Authorization",
   "Check ownership before allowing operations.": "Check ownership before allowing operations.",
+  "Derive user identity from verified JWT — never from request parameters": "Derive user identity from verified JWT — never from request parameters",
   "Check ownership": "Check ownership",
   "Data Protection": "Data Protection",
   "Encrypt Sensitive Data": "Encrypt Sensitive Data",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/data-service.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/data-service.md
@@ -21,7 +21,7 @@ DataServiceを使用する前に、[CommandServiceセクション](/docs/command
 
 ## メソッド
 
-### *async* `getItem(key: DetailKey): Promise<DataModel>`
+### *async* `getItem(key: DetailKey): Promise<DataModel | undefined>`
 
 `getItem`メソッドは、指定された詳細キー/主キーを持つアイテムの属性セットを返します。一致するアイテムがない場合、`getItem`は`undefined`を返します。
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/security-best-practices.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/security-best-practices.md
@@ -285,8 +285,10 @@ async function getOrdersByTenant(invokeContext: IInvoke) {
 async function updateOrder(
   orderId: string,
   updates: UpdateOrderDto,
-  userId: string,
-): Promise<Order> {
+  invokeContext: IInvoke,
+): Promise<CommandModel | null> {
+  // JWTから検証済みのユーザーIDを取得する — リクエストパラメーターから取得しない
+  const { userId } = getUserContext(invokeContext);
   const order = await this.dataService.getItem({ pk, sk });
 
   if (!order) {
@@ -303,7 +305,7 @@ async function updateOrder(
     sk: order.sk,
     version: order.version,
     ...updates,
-  }, options);
+  }, { invokeContext });
 }
 ```
 

--- a/i18n/ja/translation/data-service.json
+++ b/i18n/ja/translation/data-service.json
@@ -9,7 +9,7 @@
   "Query Results": "クエリ結果",
   "Before using the DataService, you need to set up the CommandModule as described in [the CommandService section](/docs/command-service).": "DataServiceを使用する前に、[CommandServiceセクション](/docs/command-service)で説明されているようにCommandModuleをセットアップする必要があります。",
   "Methods": "メソッド",
-  "*async* `getItem(key: DetailKey): Promise<DataModel>`": "*async* `getItem(key: DetailKey): Promise<DataModel>`",
+  "*async* `getItem(key: DetailKey): Promise<DataModel | undefined>`": "*async* `getItem(key: DetailKey): Promise<DataModel | undefined>`",
   "The `getItem` method returns a set of attributes for the item with the given detail/primary key. If there is no matching item, `getItem` returns `undefined`.": "`getItem`メソッドは、指定された詳細キー/主キーを持つアイテムの属性セットを返します。一致するアイテムがない場合、`getItem`は`undefined`を返します。",
   "Example:": "例：",
   "*async* `listItemsByPk(pk: string, opts?: ListItemsOptions): Promise<DataListEntity>`": "*async* `listItemsByPk(pk: string, opts?: ListItemsOptions): Promise<DataListEntity>`",

--- a/i18n/ja/translation/security-best-practices.json
+++ b/i18n/ja/translation/security-best-practices.json
@@ -37,6 +37,7 @@
   "Tenant is always part of the partition key": "テナントは常にパーティションキーの一部",
   "Resource-Level Authorization": "リソースレベルの認可",
   "Check ownership before allowing operations.": "操作を許可する前に所有権を確認します。",
+  "Derive user identity from verified JWT — never from request parameters": "JWTから検証済みのユーザーIDを取得する — リクエストパラメーターから取得しない",
   "Check ownership": "所有権を確認",
   "Data Protection": "データ保護",
   "Encrypt Sensitive Data": "機密データの暗号化",


### PR DESCRIPTION
## Summary

**data-service.md**
- Fix `getItem()` section heading: `Promise<DataModel>` → `Promise<DataModel | undefined>`. The prose body already correctly stated it returns `undefined` when not found; the method signature heading was incomplete.

**security-best-practices.md** — Resource-Level Authorization example
- The `updateOrder` example passed `userId: string` as a function parameter — directly contradicting the guide's own rule two sections above: *"Always derive the tenant code from the verified JWT via getUserContext() — never from request parameters."* The same principle applies to `userId`. Fixed to accept `invokeContext: IInvoke` and extract `userId` via `getUserContext(invokeContext)` inside the function.
- Fix return type from `Promise<Order>` to `Promise<CommandModel | null>` (framework `publishPartialUpdateSync` returns `CommandModel | null`)
- Fix options argument from positional to `{ invokeContext }` object form

## Test plan

- [x] `npm run translate:replace-placeholders` ran cleanly
- [x] `npm run build` passes with no errors